### PR TITLE
Add PKG_CXXFLAGS to compile correctly on windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,2 @@
+PKG_CXXFLAGS=-std=gnu++0x
 PKG_LIBS=-lRiconv


### PR DESCRIPTION
Hi Hadley;

I tried to install current master of this library but it did not work.

The reason is that current windows g++ does not support C++11 functionality.
To solve this issue ,we need to add "-std=gnu++0x" flag to compile successfully.