### PR TITLE
By default, scan through whole file to determine types.

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,7 +33,7 @@ read_tokens <- function(sourceSpec, tokenizerSpec, colSpecs, col_names, n_max = 
     .Call('readr_read_tokens', PACKAGE = 'readr', sourceSpec, tokenizerSpec, colSpecs, col_names, n_max, progress)
 }
 
-collectorsGuess <- function(sourceSpec, tokenizerSpec, n = 100L) {
+collectorsGuess <- function(sourceSpec, tokenizerSpec, n = -1L) {
     .Call('readr_collectorsGuess', PACKAGE = 'readr', sourceSpec, tokenizerSpec, n)
 }
 

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -29,8 +29,8 @@ NULL
 #' # Or directly from a string (must contain a newline)
 #' read_csv("x,y\n1,2\n3,4")
 #'
-#' # By default, readr guess the columns types, looking at the first 100 rows.
-#' # You can override with a compact specification:
+#' # By default, readr will guess the columns types, doing a full scan of the
+#' file. You can override with a compact specification:
 #' read_csv("x,y\n1,2\n3,4", col_types = "dc")
 #'
 #' # Or with a list of column types:
@@ -97,7 +97,7 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
   col_names <- col_names_standardise(col_names, header(ds, tokenizer))
 
   ds <- datasource(file, skip = skip)
-  col_types <- col_types_standardise(col_types, col_names, types(ds, tokenizer))
+  col_types <- col_types_standardise(col_types, col_names, types(ds, tokenizer, n_max))
   read_tokens(ds, tokenizer, col_types, col_names, n_max = n_max,
     progress = progress)
 
@@ -109,6 +109,6 @@ header <- function(datasource, tokenizer) {
   parse_vector(first, tokenizer = tokenizer, col_character())
 }
 
-types <- function(source, tokenizer) {
-  collectorsGuess(source, tokenizer, n = 100)
+types <- function(source, tokenizer, n = -1) {
+  collectorsGuess(source, tokenizer, n)
 }


### PR DESCRIPTION
This is the nuclear method, it does have considerable performance impacts. I'm not completely sure how else to be completely certain of getting the types right besides scanning the whole file.

I'm still getting much better performance than ``read.csv``:

    > system.time(x <- read_csv('parse_resistant_data.csv'))
    user  system elapsed 
    4.312   0.281   5.345 
    > system.time(y <- fread('parse_resistant_data.csv'))
       user  system elapsed
      0.621   0.054   0.675
    > system.time(z <- read.csv('parse_resistant_data.csv'))
       user  system elapsed
     16.484   0.366  17.973



A really crazy alternative might be to watch for parse warnings when reading the whole file, and just start over with a full file scan if they do happen. That would result in unpredictable performance but it would be fast in most cases where the types are picked up correctly on the first run.