### PR TITLE
Don't show progress bar unless requested.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,10 @@ warnings_are_errors: true
 r_packages:
   - rmarkdown
 
+r_github_packages:
+  - jimhester/covr
+after_success:
+  - Rscript -e 'covr::codecov()'
+
 apt_packages:
   - libv8-dev

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,3 +28,6 @@
 
 * Compound formats %D, %F, %R, %X, %T, %x are now parsed correctly, instead of
   using the ISO8601 parser (#178, @kmillar)
+
+* The completed progress bar is no longer shown after reading a large file if
+  `progress = FALSE` (#156, @humburg)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readr 0.1.1.9000
 
+* Date time parsing now understands `%p` to parse AM/PM (and am/pm) (#126).
+
 * `read_delim()` now defaults to `escape_backslash = FALSE` and 
   `escape_double = TRUE` for consistency.  
   

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,20 +5,16 @@ collectorGuess <- function(input) {
     .Call('readr_collectorGuess', PACKAGE = 'readr', input)
 }
 
+read_connection_ <- function(con, chunk_size = 64 * 1024L) {
+    .Call('readr_read_connection_', PACKAGE = 'readr', con, chunk_size)
+}
+
 utctime <- function(year, month, day, hour, min, sec, psec, repair = FALSE) {
     .Call('readr_utctime', PACKAGE = 'readr', year, month, day, hour, min, sec, psec, repair)
 }
 
 date_time_locale <- function() {
     .Call('readr_date_time_locale', PACKAGE = 'readr')
-}
-
-whitespaceColumns <- function(sourceSpec, n = 100L) {
-    .Call('readr_whitespaceColumns', PACKAGE = 'readr', sourceSpec, n)
-}
-
-read_connection_ <- function(con, chunk_size = 64 * 1024L) {
-    .Call('readr_read_connection_', PACKAGE = 'readr', con, chunk_size)
 }
 
 dim_tokens_ <- function(sourceSpec, tokenizerSpec) {
@@ -51,6 +47,10 @@ read_tokens <- function(sourceSpec, tokenizerSpec, colSpecs, col_names, n_max = 
 
 collectorsGuess <- function(sourceSpec, tokenizerSpec, n = 100L) {
     .Call('readr_collectorsGuess', PACKAGE = 'readr', sourceSpec, tokenizerSpec, n)
+}
+
+whitespaceColumns <- function(sourceSpec, n = 100L) {
+    .Call('readr_whitespaceColumns', PACKAGE = 'readr', sourceSpec, n)
 }
 
 type_convert_col <- function(x, spec, col) {

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -175,6 +175,7 @@ col_skip <- function() {
 #'   \item Seconds: "\%S" (integer seconds), "\%OS" (partial seconds)
 #'   \item Time zone: "\%Z" (as name, e.g. "America/Chicago"), "\%z" (as
 #'     offset from UTC, e.g. "+0800")
+#'   \item AM/PM indicator: "\%p".
 #'   \item Non-digits: "\%." skips one non-digit charcter, "\%*" skips any
 #'     number of non-digits characters.
 #'   \item Shortcuts: "\%D" = "\%m/\%d/\%y",  "\%F" = "\%Y-\%m-\%d",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # readr
 
 [![Build Status](https://travis-ci.org/hadley/readr.png?branch=master)](https://travis-ci.org/hadley/readr)
+[![Coverage Status](https://img.shields.io/codecov/c/github/hadley/readr/master.svg)](https://codecov.io/github/hadley/readr?branch=master)
 
 The goal of readr is to provide a fast and friendly way to read tabular data into R. The most important functions are:
 

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -74,6 +74,7 @@ There are three types of element:
   \item Seconds: "\%S" (integer seconds), "\%OS" (partial seconds)
   \item Time zone: "\%Z" (as name, e.g. "America/Chicago"), "\%z" (as
     offset from UTC, e.g. "+0800")
+  \item AM/PM indicator: "\%p".
   \item Non-digits: "\%." skips one non-digit charcter, "\%*" skips any
     number of non-digits characters.
   \item Shortcuts: "\%D" = "\%m/\%d/\%y",  "\%F" = "\%Y-\%m-\%d",

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -16,6 +16,18 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// read_connection_
+RawVector read_connection_(RObject con, int chunk_size);
+RcppExport SEXP readr_read_connection_(SEXP conSEXP, SEXP chunk_sizeSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< RObject >::type con(conSEXP);
+    Rcpp::traits::input_parameter< int >::type chunk_size(chunk_sizeSEXP);
+    __result = Rcpp::wrap(read_connection_(con, chunk_size));
+    return __result;
+END_RCPP
+}
 // utctime
 NumericVector utctime(IntegerVector year, IntegerVector month, IntegerVector day, IntegerVector hour, IntegerVector min, IntegerVector sec, NumericVector psec, bool repair);
 RcppExport SEXP readr_utctime(SEXP yearSEXP, SEXP monthSEXP, SEXP daySEXP, SEXP hourSEXP, SEXP minSEXP, SEXP secSEXP, SEXP psecSEXP, SEXP repairSEXP) {
@@ -41,30 +53,6 @@ BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
     __result = Rcpp::wrap(date_time_locale());
-    return __result;
-END_RCPP
-}
-// whitespaceColumns
-List whitespaceColumns(List sourceSpec, int n);
-RcppExport SEXP readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject __result;
-    Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
-    Rcpp::traits::input_parameter< int >::type n(nSEXP);
-    __result = Rcpp::wrap(whitespaceColumns(sourceSpec, n));
-    return __result;
-END_RCPP
-}
-// read_connection_
-RawVector read_connection_(RObject con, int chunk_size);
-RcppExport SEXP readr_read_connection_(SEXP conSEXP, SEXP chunk_sizeSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject __result;
-    Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< RObject >::type con(conSEXP);
-    Rcpp::traits::input_parameter< int >::type chunk_size(chunk_sizeSEXP);
-    __result = Rcpp::wrap(read_connection_(con, chunk_size));
     return __result;
 END_RCPP
 }
@@ -166,6 +154,18 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< List >::type tokenizerSpec(tokenizerSpecSEXP);
     Rcpp::traits::input_parameter< int >::type n(nSEXP);
     __result = Rcpp::wrap(collectorsGuess(sourceSpec, tokenizerSpec, n));
+    return __result;
+END_RCPP
+}
+// whitespaceColumns
+List whitespaceColumns(List sourceSpec, int n);
+RcppExport SEXP readr_whitespaceColumns(SEXP sourceSpecSEXP, SEXP nSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< List >::type sourceSpec(sourceSpecSEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    __result = Rcpp::wrap(whitespaceColumns(sourceSpec, n));
     return __result;
 END_RCPP
 }

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -119,7 +119,9 @@ RObject read_tokens(List sourceSpec, List tokenizerSpec, ListOf<List> colSpecs,
     collectors[t.col()]->setValue(t.row(), t);
     i = t.row();
   }
-  progressBar.show(tokenizer->progress());
+  if(progress){
+    progressBar.show(tokenizer->progress());
+  }
   progressBar.stop();
 
   if (i <= n) {

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -119,9 +119,9 @@ RObject read_tokens(List sourceSpec, List tokenizerSpec, ListOf<List> colSpecs,
     collectors[t.col()]->setValue(t.row(), t);
     i = t.row();
   }
-  if(progress){
+  if (progress)
     progressBar.show(tokenizer->progress());
-  }
+    
   progressBar.stop();
 
   if (i <= n) {

--- a/tests/testthat/test-collectors.R
+++ b/tests/testthat/test-collectors.R
@@ -7,3 +7,19 @@ test_that("guess for empty vector is character", {
 test_that("guess for missing vector is character", {
   expect_equal(collectorGuess(NA_character_), "character")
 })
+
+
+# Concise collectors specification ----------------------------------------
+
+test_that("_ or - skips column", {
+  out1 <- read_csv("x,y\n1,2\n3,4", col_types = "-i")
+  out2 <- read_csv("x,y\n1,2\n3,4", col_types = "_i")
+
+  expect_equal(names(out1), "y")
+  expect_equal(names(out2), "y")
+})
+
+test_that("? guesses column type", {
+  out1 <- read_csv("x,y\n1,2\n3,4", col_types = "?i")
+  expect_equal(out1$x, c(1L, 3L))
+})

--- a/tests/testthat/test-datetime.R
+++ b/tests/testthat/test-datetime.R
@@ -31,7 +31,7 @@ test_that("Compound formats work", {
   expect_equal(parse_datetime("02/03/10", "%D"), target)
   expect_equal(parse_datetime("2010-02-03", "%F"), target)
   expect_equal(parse_datetime("10/02/03", "%x"), target)
-}
+})
 
 test_that("%y matches R behaviour", {
   expect_equal(

--- a/tests/testthat/test-datetime.R
+++ b/tests/testthat/test-datetime.R
@@ -76,6 +76,13 @@ test_that("ISO8601 partial dates fill in month and day", {
   expect_equal(parse_datetime("2001-01"), ref)
 })
 
+test_that("%p detects AM/PM", {
+  am <- parse_datetime(c("2015-01-01 01:00 AM", "2015-01-01 01:00 am"), "%F %R %p")
+  pm <- parse_datetime(c("2015-01-01 01:00 PM", "2015-01-01 01:00 pm"), "%F %R %p")
+
+  expect_equal(pm, am + 12 * 3600)
+})
+
 # Time zones ------------------------------------------------------------------
 
 test_that("same times with different offsets parsed as same time", {


### PR DESCRIPTION
The (completed) progress bar was always displayed after loading sufficiently large files even with `progress = FALSE`.