### PR TITLE
Add github link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,5 @@ Suggests:
     knitr,
     DiagrammeR
 License: GPL (>= 2)
+BugReports: https://github.com/hadley/readr/issues
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,5 @@ Suggests:
     DiagrammeR
 License: GPL (>= 2)
 BugReports: https://github.com/hadley/readr/issues
+URL: https://github.com/hadley/readr
 VignetteBuilder: knitr


### PR DESCRIPTION
Adds a BugReports link to the DESCRIPTION file so that CRAN-sourcing users can find the repo easily if they run into problems or have patches.