### PR TITLE
Fix type_convert()

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -77,10 +77,13 @@ col_types_full <- function(col_types, col_names, guessed_types) {
         paste0(bad_names, collapse = ", "), call. = FALSE)
     }
 
-    skip <- setdiff(col_names, names(col_types))
-    if (length(skip) > 0) {
+    # if no names given for guessed_types, assume it matches the col_names order
+    if ( is.null(names(guessed_types)) && length(guessed_types) == length(col_names) )
       names(guessed_types) <- col_names
-      col_types[skip] <- lapply(guessed_types[skip], collector_find)
+    # use the guessed column type, unless it was already explicitly specified
+    guessed <- intersect(setdiff(col_names, names(col_types)), names(guessed_types))
+    if (length(guessed) > 0) {
+      col_types[guessed] <- lapply(guessed_types[guessed], collector_find)
     }
 
     col_types[match(col_names, names(col_types))]


### PR DESCRIPTION
The current behavior of `type_convert()` is not very practical:
 * it automatically converts all the character columns into the guessed type, if none explicitly specified
 * the current implementation of `col_types_full()` works only under the assumption that all columns have guessed type

The PR tries to fix the two issues. However, it only works when the conversion is from character to any other type, if e.g. one needs to convert integer into numeric, it would fail. This needs to be fixed in `type_convert_col()`.