### PR TITLE
Fix a bug in DateTimeParser where compound formats would get parsed as

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,3 +17,5 @@
 * When guessing field types, and there's no information to go on, use
   character instead of logical (#124, #128).
 
+* Compound formats %D, %F, %R, %X, %T, %x are now parsed correctly, instead of
+  using the ISO8601 parser (#178, @kmillar)

--- a/src/CollectorDate.h
+++ b/src/CollectorDate.h
@@ -31,7 +31,8 @@ public:
       std::string std_string(string.first, string.second);
 
       parser_.setDate(std_string.c_str());
-      bool res = (format_ == "") ? parser_.parse() : parser_.parse(format_);
+      bool res = (format_ == "") ? parser_.parseISO8601()
+        : parser_.parse(format_);
 
       if (!res) {
         warn(t.row(), t.col(), "date like " +  format_, std_string);

--- a/src/CollectorDateTime.h
+++ b/src/CollectorDateTime.h
@@ -57,7 +57,8 @@ public:
       std::string std_string(string.first, string.second);
 
       parser_.setDate(std_string.c_str());
-      bool res = (format_ == "") ? parser_.parse() : parser_.parse(format_);
+      bool res = (format_ == "") ? parser_.parseISO8601()
+        : parser_.parse(format_);
 
       if (!res) {
         warn(t.row(), t.col(), "date like " +  format_, std_string);
@@ -92,7 +93,7 @@ public:
     DateTimeParser parser(loc, "UTC");
 
     parser.setDate(x.c_str());
-    return parser.parse(false);
+    return parser.parseISO8601(false);
   }
 
 };

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -92,6 +92,10 @@ public:
     reset();
   }
 
+  bool parse(const char* format) {
+    return parse(std::string(format));
+  }
+
   bool parse(const std::string& format) {
     consumeWhiteSpace(); // always consume leading whitespace
 

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -35,7 +35,7 @@ public:
   // Parse ISO8601 date time. In benchmarks this only seems ~30% faster than
   // parsing with a format string so it doesn't seem necessary to add individual
   // parsers for other common formats.
-  bool parse(bool partial = true) {
+  bool parseISO8601(bool partial = true) {
     // Support partial specifications - this is normally ok, but don't want
     // to turn on when guessing formats as it's too liberal
     if (partial) {
@@ -90,10 +90,6 @@ public:
   void setDate(const char* date) {
     init(date);
     reset();
-  }
-
-  bool parse(const char* format) {
-    return parse(std::string(format));
   }
 
   bool parse(const std::string& format) {

--- a/tests/testthat/test-datetime.R
+++ b/tests/testthat/test-datetime.R
@@ -25,6 +25,14 @@ test_that("%d, %m and %y", {
   expect_equal(parse_datetime("02/03/10", "%m/%d/%y"), target)
 })
 
+test_that("Compound formats work", {
+  target <- utctime(2010, 2, 3, 0, 0, 0, 0)
+
+  expect_equal(parse_datetime("02/03/10", "%D"), target)
+  expect_equal(parse_datetime("2010-02-03", "%F"), target)
+  expect_equal(parse_datetime("10/02/03", "%x"), target)
+}
+
 test_that("%y matches R behaviour", {
   expect_equal(
     parse_datetime("01-01-69", "%d-%m-%y"),


### PR DESCRIPTION
partial ISO8601 date time format.