### PR TITLE
clarify write_* docs (append param).

### DIFF
--- a/R/write.R
+++ b/R/write.R
@@ -16,8 +16,9 @@
 #' @param x A data frame to write to disk
 #' @param path Path to write to. If \code{""} will return the csv file as
 #'   a string.
-#' @param append If \code{FALSE}, will create a new file. If \code{TRUE},
-#'   will append to an existing file.
+#' @param append If \code{FALSE}, will overwrite existing file. If \code{TRUE},
+#'   will append to existing file. In both cases, if file does not exist a new
+#'   file is created.
 #' @param col_names Write columns names at the top of the file?
 #' @param delim Delimiter used to seperate values. Defaults to \code{" "}. Must be
 #'   a single character.

--- a/man/write_delim.Rd
+++ b/man/write_delim.Rd
@@ -24,8 +24,9 @@ a string.}
 \item{delim}{Delimiter used to seperate values. Defaults to \code{" "}. Must be
 a single character.}
 
-\item{append}{If \code{FALSE}, will create a new file. If \code{TRUE},
-will append to an existing file.}
+\item{append}{If \code{FALSE}, will overwrite existing file. If \code{TRUE},
+will append to existing file. In both cases, if file does not exist a new
+file is created.}
 
 \item{col_names}{Write columns names at the top of the file?}
 }


### PR DESCRIPTION
Modified documentation for the `append` param for the `write_*` functions to make it clear that if a file does not previously exist a new file is created.

This is to address / fix #181 .