### PR TITLE
Allow multiple strings for missing values and correctly treat na = ""

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,3 +17,5 @@
 * When guessing field types, and there's no information to go on, use
   character instead of logical (#124, #128).
 
+* Multiple strings can now be specified to indicate missing values (#125).
+  Specifying `na = ""` now works as expected with character columns (#114).

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,5 +17,7 @@
 * When guessing field types, and there's no information to go on, use
   character instead of logical (#124, #128).
 
-* Multiple strings can now be specified to indicate missing values (#125).
+* Multiple strings can now be specified to indicate missing values (#125), and
+  the default for missing strings has been changed to `na = c("", "NA")`.
   Specifying `na = ""` now works as expected with character columns (#114).
+  

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -20,7 +20,7 @@ NULL
 #'   in an interactive session. The display is updated every 50,000 values
 #'   and will only display if estimated reading time is 5 seconds or more.
 #' @usage read_delim(file, delim, quote = '\"', escape_backslash = FALSE,
-#'   escape_double = TRUE, na = "NA", col_names = TRUE, col_types = NULL,
+#'   escape_double = TRUE, na = c("", "NA"), col_names = TRUE, col_types = NULL,
 #'   skip = 0, n_max = -1, progress = interactive())
 #' @return A data frame. If there are parsing problems, a warning tells you
 #'   how many, and you can retrieve the details with \code{\link{problems}()}.
@@ -56,7 +56,7 @@ NULL
 #' read_tsv("a\tb\n1.0\t2.0")
 #' read_delim("a|b\n1.0|2.0", delim = "|")
 read_delim <- function(file, delim, quote = '"', escape_backslash = FALSE,
-                       escape_double = TRUE, na = "NA", col_names = TRUE,
+                       escape_double = TRUE, na = c("", "NA"), col_names = TRUE,
                        col_types = NULL, skip = 0, n_max = -1,
                        progress = interactive()) {
   tokenizer <- tokenizer_delim(delim, quote = quote,
@@ -68,7 +68,7 @@ read_delim <- function(file, delim, quote = '"', escape_backslash = FALSE,
 
 #' @rdname read_delim
 #' @export
-read_csv <- function(file, col_names = TRUE, col_types = NULL, na = "NA",
+read_csv <- function(file, col_names = TRUE, col_types = NULL, na = c("", "NA"),
                      skip = 0, n_max = -1, progress = interactive()) {
 
   tokenizer <- tokenizer_csv(na = na)
@@ -78,8 +78,9 @@ read_csv <- function(file, col_names = TRUE, col_types = NULL, na = "NA",
 
 #' @rdname read_delim
 #' @export
-read_csv2 <- function(file, col_names = TRUE, col_types = NULL, na = "NA",
-                      skip = 0, n_max = -1, progress = interactive()) {
+read_csv2 <- function(file, col_names = TRUE, col_types = NULL,
+                      na = c("", "NA"), skip = 0, n_max = -1,
+                      progress = interactive()) {
 
   tokenizer <- tokenizer_delim(delim = ";", na = na)
   read_delimited(file, tokenizer, col_names = col_names, col_types = col_types,
@@ -89,7 +90,7 @@ read_csv2 <- function(file, col_names = TRUE, col_types = NULL, na = "NA",
 
 #' @rdname read_delim
 #' @export
-read_tsv <- function(file, col_names = TRUE, col_types = NULL, na = "NA",
+read_tsv <- function(file, col_names = TRUE, col_types = NULL, na = c("", "NA"),
                      skip = 0, n_max = -1, progress = interactive()) {
 
   tokenizer <- tokenizer_tsv(na = na)

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -28,8 +28,8 @@
 #' read_fwf(fwf_sample, fwf_widths(c(2, 5, 3)))
 #' # 3. Paired vectors of start and end positions
 #' read_fwf(fwf_sample, fwf_positions(c(1, 4), c(2, 10)))
-read_fwf <- function(file, col_positions, col_types = NULL, na = "NA", skip = 0,
-                     n_max = -1, progress = interactive()) {
+read_fwf <- function(file, col_positions, col_types = NULL, na = c("", "NA"),
+                     skip = 0, n_max = -1, progress = interactive()) {
   ds <- datasource(file, skip = skip)
   tokenizer <- tokenizer_fwf(col_positions$begin, col_positions$end, na = na)
 

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -35,7 +35,7 @@ NULL
 #' @export
 #' @rdname Tokenizers
 #' @param na Character vector of strings to use for missing values. Set this
-#'   option to \code{NULL} to indicate no missing values.
+#'   option to \code{character()} to indicate no missing values.
 #' @param delim Single character used to separate fields within a record.
 #' @param quote Single character used to quote strings.
 #' @param escape_double Does the file escape quotes by doubling them?

--- a/R/tokenizer.R
+++ b/R/tokenizer.R
@@ -34,7 +34,8 @@ NULL
 
 #' @export
 #' @rdname Tokenizers
-#' @param na String to use for missing values.
+#' @param na Character vector of strings to use for missing values. Set this
+#'   option to \code{NULL} to indicate no missing values.
 #' @param delim Single character used to separate fields within a record.
 #' @param quote Single character used to quote strings.
 #' @param escape_double Does the file escape quotes by doubling them?

--- a/man/Tokenizers.Rd
+++ b/man/Tokenizers.Rd
@@ -28,7 +28,8 @@ tokenizer_fwf(begin, end, na = "NA")
 
 \item{quote}{Single character used to quote strings.}
 
-\item{na}{String to use for missing values.}
+\item{na}{Character vector of strings to use for missing values. Set this
+option to \code{NULL} to indicate no missing values.}
 
 \item{escape_double}{Does the file escape quotes by doubling them?
 i.e. If this option is \code{TRUE}, the value \code{""""} represents

--- a/man/Tokenizers.Rd
+++ b/man/Tokenizers.Rd
@@ -29,7 +29,7 @@ tokenizer_fwf(begin, end, na = "NA")
 \item{quote}{Single character used to quote strings.}
 
 \item{na}{Character vector of strings to use for missing values. Set this
-option to \code{NULL} to indicate no missing values.}
+option to \code{character()} to indicate no missing values.}
 
 \item{escape_double}{Does the file escape quotes by doubling them?
 i.e. If this option is \code{TRUE}, the value \code{""""} represents

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -45,7 +45,8 @@ to add special characters like \code{\\n}.}
 i.e. If this option is \code{TRUE}, the value \code{""""} represents
 a single quote, \code{\"}.}
 
-\item{na}{String to use for missing values.}
+\item{na}{Character vector of strings to use for missing values. Set this
+option to \code{NULL} to indicate no missing values.}
 
 \item{col_names}{Either \code{TRUE}, \code{FALSE} or a character vector
   of column names.

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -8,17 +8,17 @@
 \title{Read a delimited file into a data frame.}
 \usage{
 read_delim(file, delim, quote = '\"', escape_backslash = FALSE,
-  escape_double = TRUE, na = "NA", col_names = TRUE, col_types = NULL,
+  escape_double = TRUE, na = c("", "NA"), col_names = TRUE, col_types = NULL,
   skip = 0, n_max = -1, progress = interactive())
 
-read_csv(file, col_names = TRUE, col_types = NULL, na = "NA", skip = 0,
-  n_max = -1, progress = interactive())
+read_csv(file, col_names = TRUE, col_types = NULL, na = c("", "NA"),
+  skip = 0, n_max = -1, progress = interactive())
 
-read_csv2(file, col_names = TRUE, col_types = NULL, na = "NA", skip = 0,
-  n_max = -1, progress = interactive())
+read_csv2(file, col_names = TRUE, col_types = NULL, na = c("", "NA"),
+  skip = 0, n_max = -1, progress = interactive())
 
-read_tsv(file, col_names = TRUE, col_types = NULL, na = "NA", skip = 0,
-  n_max = -1, progress = interactive())
+read_tsv(file, col_names = TRUE, col_types = NULL, na = c("", "NA"),
+  skip = 0, n_max = -1, progress = interactive())
 }
 \arguments{
 \item{file}{Either a path to a file, a connection, or literal data
@@ -46,7 +46,7 @@ i.e. If this option is \code{TRUE}, the value \code{""""} represents
 a single quote, \code{\"}.}
 
 \item{na}{Character vector of strings to use for missing values. Set this
-option to \code{NULL} to indicate no missing values.}
+option to \code{character()} to indicate no missing values.}
 
 \item{col_names}{Either \code{TRUE}, \code{FALSE} or a character vector
   of column names.

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -48,7 +48,8 @@ use \code{fwf_positions}.}
   character represents one column: c = character, d = double, i = integer,
   l = logical and \code{_} skips the column.}
 
-\item{na}{String to use for missing values.}
+\item{na}{Character vector of strings to use for missing values. Set this
+option to \code{NULL} to indicate no missing values.}
 
 \item{skip}{Number of lines to skip before reading data.}
 

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -7,8 +7,8 @@
 \alias{read_fwf}
 \title{Read a fixed width file.}
 \usage{
-read_fwf(file, col_positions, col_types = NULL, na = "NA", skip = 0,
-  n_max = -1, progress = interactive())
+read_fwf(file, col_positions, col_types = NULL, na = c("", "NA"),
+  skip = 0, n_max = -1, progress = interactive())
 
 fwf_empty(file, skip = 0, col_names = NULL)
 
@@ -49,7 +49,7 @@ use \code{fwf_positions}.}
   l = logical and \code{_} skips the column.}
 
 \item{na}{Character vector of strings to use for missing values. Set this
-option to \code{NULL} to indicate no missing values.}
+option to \code{character()} to indicate no missing values.}
 
 \item{skip}{Number of lines to skip before reading data.}
 

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -47,7 +47,7 @@ read_table(file, col_names = TRUE, col_types = NULL, na = "NA",
   l = logical and \code{_} skips the column.}
 
 \item{na}{Character vector of strings to use for missing values. Set this
-option to \code{NULL} to indicate no missing values.}
+option to \code{character()} to indicate no missing values.}
 
 \item{skip}{Number of lines to skip before reading data.}
 

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -46,7 +46,8 @@ read_table(file, col_names = TRUE, col_types = NULL, na = "NA",
   character represents one column: c = character, d = double, i = integer,
   l = logical and \code{_} skips the column.}
 
-\item{na}{String to use for missing values.}
+\item{na}{Character vector of strings to use for missing values. Set this
+option to \code{NULL} to indicate no missing values.}
 
 \item{skip}{Number of lines to skip before reading data.}
 

--- a/src/Token.h
+++ b/src/Token.h
@@ -86,10 +86,10 @@ public:
 
     std::vector<std::string>::iterator it;
     for (it = NA.begin(); it != NA.end(); ++it) {
-      if ((size_t) (end_ - begin_) != (*it).size())
+      if ((size_t) (end_ - begin_) != it->size())
         continue;
 
-      if (strncmp(begin_, &(*it)[0], (*it).size()) == 0) {
+      if (strncmp(begin_, it->data(), it->size()) == 0) {
         type_ = TOKEN_MISSING;
         break;
       }

--- a/src/Token.h
+++ b/src/Token.h
@@ -82,14 +82,19 @@ public:
     return *this;
   }
 
-  Token& flagNA(std::string NA) {
-    if ((size_t) (end_ - begin_) != NA.size())
-      return *this;
+  Token& flagNA(std::vector<std::string> NA) {
 
-    if (strncmp(begin_, &NA[0], NA.size()) != 0)
-      return *this;
+    std::vector<std::string>::iterator it;
+    for (it = NA.begin(); it != NA.end(); ++it) {
+      if ((size_t) (end_ - begin_) != (*it).size())
+        continue;
 
-    type_ = TOKEN_MISSING;
+      if (strncmp(begin_, &(*it)[0], (*it).size()) == 0) {
+        type_ = TOKEN_MISSING;
+        break;
+      }
+    }
+
     return *this;
   }
 

--- a/src/Tokenizer.cpp
+++ b/src/Tokenizer.cpp
@@ -14,14 +14,7 @@ TokenizerPtr Tokenizer::create(List spec) {
   if (subclass == "tokenizer_delim") {
     char delim = as<char>(spec["delim"]);
     char quote = as<char>(spec["quote"]);
-
-    std::vector<std::string> na;
-    if (Rf_isNull(spec["na"])) {
-      na = std::vector<std::string>();
-    } else {
-      na = as<std::vector<std::string> >(spec["na"]);
-    }
-
+    std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
     bool escapeDouble = as<bool>(spec["escape_double"]);
     bool escapeBackslash = as<bool>(spec["escape_backslash"]);
 
@@ -32,13 +25,7 @@ TokenizerPtr Tokenizer::create(List spec) {
     std::vector<int>
       begin = as<std::vector<int> >(spec["begin"]),
       end = as<std::vector<int> >(spec["end"]);
-
-    std::vector<std::string> na;
-    if (Rf_isNull(spec["na"])) {
-      na = std::vector<std::string>();
-    } else {
-      na = as<std::vector<std::string> >(spec["na"]);
-    }
+    std::vector<std::string> na = as<std::vector<std::string> >(spec["na"]);
 
     return TokenizerPtr(new TokenizerFwf(begin, end, na));
   } else if (subclass == "tokenizer_line") {

--- a/src/Tokenizer.cpp
+++ b/src/Tokenizer.cpp
@@ -14,7 +14,14 @@ TokenizerPtr Tokenizer::create(List spec) {
   if (subclass == "tokenizer_delim") {
     char delim = as<char>(spec["delim"]);
     char quote = as<char>(spec["quote"]);
-    std::string na = as<std::string>(spec["na"]);
+
+    std::vector<std::string> na;
+    if (Rf_isNull(spec["na"])) {
+      na = std::vector<std::string>();
+    } else {
+      na = as<std::vector<std::string> >(spec["na"]);
+    }
+
     bool escapeDouble = as<bool>(spec["escape_double"]);
     bool escapeBackslash = as<bool>(spec["escape_backslash"]);
 
@@ -26,7 +33,12 @@ TokenizerPtr Tokenizer::create(List spec) {
       begin = as<std::vector<int> >(spec["begin"]),
       end = as<std::vector<int> >(spec["end"]);
 
-    std::string na = as<std::string>(spec["na"]);
+    std::vector<std::string> na;
+    if (Rf_isNull(spec["na"])) {
+      na = std::vector<std::string>();
+    } else {
+      na = as<std::vector<std::string> >(spec["na"]);
+    }
 
     return TokenizerPtr(new TokenizerFwf(begin, end, na));
   } else if (subclass == "tokenizer_line") {

--- a/src/TokenizerDelim.h
+++ b/src/TokenizerDelim.h
@@ -18,7 +18,7 @@ enum DelimState {
 
 class TokenizerDelim : public Tokenizer {
   char delim_, quote_;
-  std::string NA_;
+  std::vector<std::string> NA_;
 
   bool escapeBackslash_, escapeDouble_;
 
@@ -29,7 +29,8 @@ class TokenizerDelim : public Tokenizer {
 
 public:
 
-  TokenizerDelim(char delim = ',', char quote = '"', std::string NA = "NA",
+  TokenizerDelim(char delim = ',', char quote = '"',
+               std::vector<std::string> NA = std::vector<std::string>(1, "NA"),
                bool escapeBackslash = false, bool escapeDouble = true):
     delim_(delim),
     quote_(quote),

--- a/src/TokenizerDelim.h
+++ b/src/TokenizerDelim.h
@@ -80,10 +80,10 @@ public:
         if (*cur_ == '\r' || *cur_ == '\n') {
           newRecord();
           advanceForLF(&cur_, end_);
-          return Token(TOKEN_EMPTY, row, col);
+          return emptyToken(row, col);
         } else if (*cur_ == delim_) {
           newField();
-          return Token(TOKEN_EMPTY, row, col);
+          return emptyToken(row, col);
         } else if (*cur_ == quote_) {
           state_ = STATE_STRING;
         } else if (escapeBackslash_ && *cur_ == '\\') {
@@ -169,7 +169,7 @@ public:
       if (col_ == 0) {
         return Token(TOKEN_EOF, row, col);
       } else {
-        return Token(TOKEN_EMPTY, row, col);
+        return emptyToken(row, col);
       }
 
     case STATE_STRING_END:
@@ -205,6 +205,10 @@ private:
     state_ = STATE_DELIM;
   }
 
+  Token emptyToken(int row, int col) {
+    return Token(TOKEN_EMPTY, row, col).flagNA(NA_);
+  }
+
   Token fieldToken(SourceIterator begin, SourceIterator end, bool hasEscapeB,
                    int row, int col) {
     return Token(begin, end, row, col, (hasEscapeB) ? this : NULL).flagNA(NA_);
@@ -215,6 +219,7 @@ private:
     return Token(begin, end, row, col,
       (hasEscapeD || hasEscapeB) ? this : NULL);
   }
+
 
 public:
 

--- a/src/TokenizerFwf.h
+++ b/src/TokenizerFwf.h
@@ -9,7 +9,7 @@
 class TokenizerFwf : public Tokenizer {
   // Begin and end offsets are inclusive to match R conventions
   std::vector<int> beginOffset_, endOffset_;
-  std::string NA_;
+  std::vector<std::string> NA_;
 
   SourceIterator begin_, curLine_, end_;
   int row_, col_, cols_, max_;
@@ -17,7 +17,8 @@ class TokenizerFwf : public Tokenizer {
 
 public:
 
-  TokenizerFwf(std::vector<int> beginOffset, std::vector<int> endOffset, std::string NA = "NA"):
+  TokenizerFwf(std::vector<int> beginOffset, std::vector<int> endOffset,
+               std::vector<std::string> NA = std::vector<std::string>(1, "NA")):
     beginOffset_(beginOffset),
     endOffset_(endOffset),
     NA_(NA),

--- a/src/TokenizerLog.h
+++ b/src/TokenizerLog.h
@@ -167,7 +167,7 @@ private:
   }
 
   Token fieldToken(SourceIterator begin, SourceIterator end, int row, int col) {
-    return Token(begin, end, row, col).flagNA("-");
+    return Token(begin, end, row, col).flagNA(std::vector<std::string>(1, "-"));
   }
 
 };

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -12,6 +12,18 @@ test_that("read_csv's 'NA' option genuinely changes the NA values", {
   expect_equal(read_csv("a\nz", na = "z")$a, NA_character_)
 })
 
+test_that("read_csv's 'NA' option works with multiple NA values", {
+  expect_equal(read_csv("a\n1\nmiss\n13", na = c("13", "miss"))$a, c(1, NA, NA))
+})
+
+test_that("passing NULL to read_csv's 'NA' option reads \"\" correctly", {
+  expect_equal(read_csv("a\nfoo\n\n", na = NULL)$a, c("foo", ""))
+})
+
+test_that("passing \"\" to read_csv's 'NA' option reads \"\" correctly", {
+  expect_equal(read_csv("a\nfoo\n\n", na = "")$a, c("foo", NA))
+})
+
 test_that("read_csv's 'skip' option allows for skipping'", {
   test_data <- read_csv("basic-df.csv", skip = 1)
   expect_equal(nrow(test_data), 9)

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -13,7 +13,8 @@ test_that("read_csv's 'NA' option genuinely changes the NA values", {
 })
 
 test_that("read_csv's 'NA' option works with multiple NA values", {
-  expect_equal(read_csv("a\n1\nmiss\n13", na = c("13", "miss"))$a, c(1, NA, NA))
+  expect_equal(read_csv("a\nNA\n\nmiss\n13", na = c("13", "miss"))$a,
+               c("NA", "", NA, NA))
 })
 
 test_that("passing NULL to read_csv's 'NA' option reads \"\" correctly", {

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -17,8 +17,8 @@ test_that("read_csv's 'NA' option works with multiple NA values", {
                c("NA", "", NA, NA))
 })
 
-test_that("passing NULL to read_csv's 'NA' option reads \"\" correctly", {
-  expect_equal(read_csv("a\nfoo\n\n", na = NULL)$a, c("foo", ""))
+test_that('passing character() to read_csv\'s "NA" option reads "" correctly', {
+  expect_equal(read_csv("a\nfoo\n\n", na = character())$a, c("foo", ""))
 })
 
 test_that("passing \"\" to read_csv's 'NA' option reads \"\" correctly", {

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -8,3 +8,8 @@ test_that("trailing spaces ommitted", {
   df <- read_fwf("fwf-trailing.txt", spec)
   expect_equal(df$X1, df$X2)
 })
+
+test_that("passing \"\" to read_fwf's 'na' option", {
+  expect_equal(read_fwf('foobar\nfoo   ', fwf_widths(c(3, 3)), na = "")[[2]],
+               c("bar", NA))
+})


### PR DESCRIPTION
Addresses #125 and #114.

I tried to follow the conventions of `utils::read.table`, namely `na = NULL` indicates no missing values while `na = ""` indicates that empty strings should be interpreted as missing values:

```r
example = "a,b
1,foo
,
"

f = textConnection(example)
read.csv(f, colClasses = c(a = "integer", b = "character"), na.strings = NULL)
#>    a   b
#> 1  1 foo
#> 2 NA    
close(f)

f = textConnection(example)
read.csv(f, colClasses = c(a = "integer", b = "character"), na.strings = "")
#>    a    b
#> 1  1  foo
#> 2 NA <NA>
close(f)
```

The implementation of `Token::flagNA` is a simple loop, I'm happy to do a performance comparison with less naive implementations if the behaviour is correct (although I suspect that the simple loop will win for small numbers of `na` strings).