### PR TITLE
Fix daylight savings bug for unambiguous times. Closes #120

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,3 +40,6 @@
 
 * Compound formats %D, %F, %R, %X, %T, %x are now parsed correctly, instead of
   using the ISO8601 parser (#178, @kmillar)
+  
+* Local (non-UTC) times with and without daylight savings are now parsed
+  correctly (#120, @andres-s).

--- a/src/DateTime.h
+++ b/src/DateTime.h
@@ -261,6 +261,10 @@ private:
     tm.tm_hour = hour_;
     tm.tm_min = min_;
     tm.tm_sec = sec_;
+    // The Daylight Saving Time flag (tm_isdst) is greater than zero if Daylight
+    // Saving Time is in effect, zero if Daylight Saving Time is not in effect,
+    // and less than zero if the information is not available.
+    tm.tm_isdst = -1;
 
     time_t time = mktime(&tm);
     return time + psec_ + offset_;

--- a/tests/testthat/test-datetime.R
+++ b/tests/testthat/test-datetime.R
@@ -99,3 +99,18 @@ test_that("offsets can cross date boundaries", {
     parse_datetime("2015-02-01T0100Z")
   )
 })
+
+test_that("unambiguous times with and without daylight savings", {
+  # Melbourne had daylight savings in 2015 that ended the morning of 2015-04-05
+  expect_equal(
+    parse_datetime(c("2015-04-04 12:00:00", "2015-04-06 12:00:00"),
+                   tz="Australia/Melbourne"),
+    as.POSIXct(c("2015-04-04 12:00:00", "2015-04-06 12:00:00"),
+               tz = "Australia/Melbourne")
+  )
+  # Japan didn't have daylight savings in 2015
+  expect_equal(
+    parse_datetime(c("2015-04-04 12:00:00", "2015-04-06 12:00:00"), tz="Japan"),
+    as.POSIXct(c("2015-04-04 12:00:00", "2015-04-06 12:00:00"), tz = "Japan")
+  )
+})


### PR DESCRIPTION
Note that this patch does *not* provide unambiguous nor even deterministic parsing of local times for the two hours that overlap at the end of daylight savings, as a consequence of the return value of `mktime()` being undefined for those two hours.

Perhaps the user should be warned/the return value should be fixed when parsing those two problem hours, but it's not clear how best to implement such behaviour.