### PR TITLE
Fixed bug in fwf_empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readr 0.1.1.9000
 
+* fixed minor double negation bug in `fwf_empty()` causing stopifnot on `col_names` if it was at right length (#222).
+
 * `col_euro_double()` and `parse_euro_double()` now handle negative values 
   (#213).
 

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -49,7 +49,7 @@ fwf_empty <- function(file, skip = 0, col_names = NULL) {
   if (is.null(col_names)) {
     col_names <- paste0("X", seq_along(out$begin))
   } else {
-    stopifnot(length(out$begin) != length(col_names))
+    stopifnot(length(out$begin) == length(col_names))
   }
   out$col_names <- col_names
 


### PR DESCRIPTION
There was an unintentional double negotation when checking on the number of columns.
(this is my first pull request, so I don't know if I follow the right procedure here by doing it like this)