### PR TITLE
Augments documentation

### DIFF
--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -36,7 +36,7 @@ NULL
 #'
 #'   Alternatively, you can use a compact string representation where each
 #'   character represents one column: c = character, d = double, i = integer,
-#'   l = logical, ? = guess, or \code{_}/\code{-} to skip the column.
+#'   l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.
 #' @param locale The locale controls defaults that vary from place to place.
 #'   The default locale is US-centric (like R), but you can use
 #'   \code{\link{locale}} to create your own locale that controls things like

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -35,8 +35,11 @@ NULL
 #'   subset of the columns, use \code{\link{cols_only}}.
 #'
 #'   Alternatively, you can use a compact string representation where each
-#'   character represents one column: c = character, d = double, i = integer,
-#'   l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.
+#'   character represents one column:
+#'   c = character, i = integer, n = number,
+#'   d = double, e = European-style double, l = logical,
+#'   D = date, T = date time, t = time, ? = guess, or
+#'   \code{_}/\code{-} to skip the column.
 #' @param locale The locale controls defaults that vary from place to place.
 #'   The default locale is US-centric (like R), but you can use
 #'   \code{\link{locale}} to create your own locale that controls things like

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -36,8 +36,7 @@ NULL
 #'
 #'   Alternatively, you can use a compact string representation where each
 #'   character represents one column:
-#'   c = character, i = integer, n = number,
-#'   d = double, e = European-style double, l = logical,
+#'   c = character, i = integer, n = number, d = double, l = logical,
 #'   D = date, T = date time, t = time, ? = guess, or
 #'   \code{_}/\code{-} to skip the column.
 #' @param locale The locale controls defaults that vary from place to place.

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -36,8 +36,8 @@ NULL
 #'
 #'   Alternatively, you can use a compact string representation where each
 #'   character represents one column:
-#'   c = character, i = integer, n = number, d = double, l = logical,
-#'   D = date, T = date time, t = time, ? = guess, or
+#'   c = character, i = integer, n = number, d = double,
+#'   l = logical, D = date, T = date time, t = time, ? = guess, or
 #'   \code{_}/\code{-} to skip the column.
 #' @param locale The locale controls defaults that vary from place to place.
 #'   The default locale is US-centric (like R), but you can use

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -74,7 +74,7 @@ a single quote, \code{\"}.}
 
   Alternatively, you can use a compact string representation where each
   character represents one column: c = character, d = double, i = integer,
-  l = logical, ? = guess, or \code{_}/\code{-} to skip the column.}
+  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -73,8 +73,11 @@ a single quote, \code{\"}.}
   subset of the columns, use \code{\link{cols_only}}.
 
   Alternatively, you can use a compact string representation where each
-  character represents one column: c = character, d = double, i = integer,
-  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
+  character represents one column:
+  c = character, i = integer, n = number,
+  d = double, e = European-style double, l = logical,
+  D = date, T = date time, t = time, ? = guess, or
+  \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -74,8 +74,7 @@ a single quote, \code{\"}.}
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number,
-  d = double, e = European-style double, l = logical,
+  c = character, i = integer, n = number, d = double, l = logical,
   D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 

--- a/man/read_delim.Rd
+++ b/man/read_delim.Rd
@@ -74,8 +74,8 @@ a single quote, \code{\"}.}
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number, d = double, l = logical,
-  D = date, T = date time, t = time, ? = guess, or
+  c = character, i = integer, n = number, d = double,
+  l = logical, D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -47,8 +47,7 @@ extended to the next line break.}
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number,
-  d = double, e = European-style double, l = logical,
+  c = character, i = integer, n = number, d = double, l = logical,
   D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -47,8 +47,8 @@ extended to the next line break.}
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number, d = double, l = logical,
-  D = date, T = date time, t = time, ? = guess, or
+  c = character, i = integer, n = number, d = double,
+  l = logical, D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -47,7 +47,7 @@ extended to the next line break.}
 
   Alternatively, you can use a compact string representation where each
   character represents one column: c = character, d = double, i = integer,
-  l = logical, ? = guess, or \code{_}/\code{-} to skip the column.}
+  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/read_fwf.Rd
+++ b/man/read_fwf.Rd
@@ -46,8 +46,11 @@ extended to the next line break.}
   subset of the columns, use \code{\link{cols_only}}.
 
   Alternatively, you can use a compact string representation where each
-  character represents one column: c = character, d = double, i = integer,
-  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
+  character represents one column:
+  c = character, i = integer, n = number,
+  d = double, e = European-style double, l = logical,
+  D = date, T = date time, t = time, ? = guess, or
+  \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -44,8 +44,7 @@ read_log(file, col_names = FALSE, col_types = NULL, skip = 0,
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number,
-  d = double, e = European-style double, l = logical,
+  c = character, i = integer, n = number, d = double, l = logical,
   D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -44,8 +44,8 @@ read_log(file, col_names = FALSE, col_types = NULL, skip = 0,
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number, d = double, l = logical,
-  D = date, T = date time, t = time, ? = guess, or
+  c = character, i = integer, n = number, d = double,
+  l = logical, D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 
 \item{skip}{Number of lines to skip before reading data.}

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -43,8 +43,11 @@ read_log(file, col_names = FALSE, col_types = NULL, skip = 0,
   subset of the columns, use \code{\link{cols_only}}.
 
   Alternatively, you can use a compact string representation where each
-  character represents one column: c = character, d = double, i = integer,
-  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
+  character represents one column:
+  c = character, i = integer, n = number,
+  d = double, e = European-style double, l = logical,
+  D = date, T = date time, t = time, ? = guess, or
+  \code{_}/\code{-} to skip the column.}
 
 \item{skip}{Number of lines to skip before reading data.}
 

--- a/man/read_log.Rd
+++ b/man/read_log.Rd
@@ -44,7 +44,7 @@ read_log(file, col_names = FALSE, col_types = NULL, skip = 0,
 
   Alternatively, you can use a compact string representation where each
   character represents one column: c = character, d = double, i = integer,
-  l = logical, ? = guess, or \code{_}/\code{-} to skip the column.}
+  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
 
 \item{skip}{Number of lines to skip before reading data.}
 

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -44,8 +44,7 @@ read_table(file, col_names = TRUE, col_types = NULL,
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number,
-  d = double, e = European-style double, l = logical,
+  c = character, i = integer, n = number, d = double, l = logical,
   D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -43,8 +43,11 @@ read_table(file, col_names = TRUE, col_types = NULL,
   subset of the columns, use \code{\link{cols_only}}.
 
   Alternatively, you can use a compact string representation where each
-  character represents one column: c = character, d = double, i = integer,
-  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
+  character represents one column:
+  c = character, i = integer, n = number,
+  d = double, e = European-style double, l = logical,
+  D = date, T = date time, t = time, ? = guess, or
+  \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -44,8 +44,8 @@ read_table(file, col_names = TRUE, col_types = NULL,
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number, d = double, l = logical,
-  D = date, T = date time, t = time, ? = guess, or
+  c = character, i = integer, n = number, d = double,
+  l = logical, D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.

--- a/man/read_table.Rd
+++ b/man/read_table.Rd
@@ -44,7 +44,7 @@ read_table(file, col_names = TRUE, col_types = NULL,
 
   Alternatively, you can use a compact string representation where each
   character represents one column: c = character, d = double, i = integer,
-  l = logical, ? = guess, or \code{_}/\code{-} to skip the column.}
+  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -22,8 +22,11 @@ type_convert(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
   subset of the columns, use \code{\link{cols_only}}.
 
   Alternatively, you can use a compact string representation where each
-  character represents one column: c = character, d = double, i = integer,
-  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
+  character represents one column:
+  c = character, i = integer, n = number,
+  d = double, e = European-style double, l = logical,
+  D = date, T = date time, t = time, ? = guess, or
+  \code{_}/\code{-} to skip the column.}
 
 \item{na}{Character vector of strings to use for missing values. Set this
 option to \code{character()} to indicate no missing values.}

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -23,8 +23,8 @@ type_convert(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number, d = double, l = logical,
-  D = date, T = date time, t = time, ? = guess, or
+  c = character, i = integer, n = number, d = double,
+  l = logical, D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 
 \item{na}{Character vector of strings to use for missing values. Set this

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -23,8 +23,7 @@ type_convert(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
 
   Alternatively, you can use a compact string representation where each
   character represents one column:
-  c = character, i = integer, n = number,
-  d = double, e = European-style double, l = logical,
+  c = character, i = integer, n = number, d = double, l = logical,
   D = date, T = date time, t = time, ? = guess, or
   \code{_}/\code{-} to skip the column.}
 

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -23,7 +23,7 @@ type_convert(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
 
   Alternatively, you can use a compact string representation where each
   character represents one column: c = character, d = double, i = integer,
-  l = logical, ? = guess, or \code{_}/\code{-} to skip the column.}
+  l = logical, D = date, ? = guess, or \code{_}/\code{-} to skip the column.}
 
 \item{na}{Character vector of strings to use for missing values. Set this
 option to \code{character()} to indicate no missing values.}


### PR DESCRIPTION
Documentation now informs the user that "**D**"ate is a valid column type when using `col_types` in `read_delim()`, etc.