### PR TITLE
Fixing of ragged fixed width format files and reading a subset of columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@
 
 * `read_delim()` gains a `trim_ws` argument (#312, noamross)
 
+=======
+>>>>>>> Updated and appended read_fwf tests and NEWS.md
 # readr 0.2.2
 
 * Fix bug when checking empty values for missingness (caused valgrind issue

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # readr 0.2.2.9000
 
+* Fix bug in `read_fwf()`, it will now properly read a subset of columns.
+  If the final column is ragged, supply an NA as the final end `fwf_positions`
+  or final width `fwf_widths` position (#353,@ghaarsma).
+
 * readr now imports tibble so that you get consistent `tbl_df` behaviour 
   (#317, #385).
 

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -77,7 +77,13 @@ fwf_widths <- function(widths, col_names = NULL) {
 #' @export
 #' @param start,end Starting and ending (inclusive) positions of each field.
 fwf_positions <- function(start, end, col_names = NULL) {
-  stopifnot(length(start) == length(end))
+
+  # Support for Ragged fwf files. Remove last end element when it is Inf or NA
+  if (is.infinite(end[length(end)]) || is.na(end[length(end)])) {
+    end <- end[-length(end)]
+  }
+
+  stopifnot((length(start)-length(end)) %in% 0:1)
 
   if (is.null(col_names)) {
     col_names <- paste0("X", seq_along(start))

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -13,8 +13,8 @@
 #' @inheritParams read_delim
 #' @param col_positions Column positions, as created by \code{fwf_empty},
 #'   \code{fwf_widths} or \code{fwf_positions}. To read in only selected fields,
-#'   use \code{fwf_positions}. The width of the last column will be silently
-#'   extended to the next line break.
+#'   use \code{fwf_positions}. If the width of the last column is variable (a
+#'   ragged fwf file), supply the last end position as NA, Inf or simply ommit it.
 #' @export
 #' @examples
 #' fwf_sample <- system.file("extdata/fwf-sample.txt", package = "readr")
@@ -65,7 +65,8 @@ fwf_empty <- function(file, skip = 0, col_names = NULL) {
 
 #' @rdname read_fwf
 #' @export
-#' @param widths Width of each field.
+#' @param widths Width of each field. Use NA or Inf as width of last field when
+#'    reading a ragged fwf file.
 #' @param col_names Either NULL, or a character vector column names.
 fwf_widths <- function(widths, col_names = NULL) {
   pos <- cumsum(c(1, widths))
@@ -76,6 +77,7 @@ fwf_widths <- function(widths, col_names = NULL) {
 #' @rdname read_fwf
 #' @export
 #' @param start,end Starting and ending (inclusive) positions of each field.
+#'    Use NA or Inf as last end field when reading a ragged fwf file.
 fwf_positions <- function(start, end, col_names = NULL) {
 
   # Support for Ragged fwf files. Remove last end element when it is Inf or NA

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -77,7 +77,7 @@ fwf_widths <- function(widths, col_names = NULL) {
 #' @rdname read_fwf
 #' @export
 #' @param start,end Starting and ending (inclusive) positions of each field.
-#'    Use NA or Inf as last end field when reading a ragged fwf file.
+#'    Use NA as last end field when reading a ragged fwf file.
 fwf_positions <- function(start, end, col_names = NULL) {
 
   stopifnot(length(start) == length(end))

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -14,7 +14,7 @@
 #' @param col_positions Column positions, as created by \code{fwf_empty},
 #'   \code{fwf_widths} or \code{fwf_positions}. To read in only selected fields,
 #'   use \code{fwf_positions}. If the width of the last column is variable (a
-#'   ragged fwf file), supply the last end position as NA, Inf or simply ommit it.
+#'   ragged fwf file), supply the last end position as NA.
 #' @export
 #' @examples
 #' fwf_sample <- system.file("extdata/fwf-sample.txt", package = "readr")
@@ -65,7 +65,7 @@ fwf_empty <- function(file, skip = 0, col_names = NULL) {
 
 #' @rdname read_fwf
 #' @export
-#' @param widths Width of each field. Use NA or Inf as width of last field when
+#' @param widths Width of each field. Use NA as width of last field when
 #'    reading a ragged fwf file.
 #' @param col_names Either NULL, or a character vector column names.
 fwf_widths <- function(widths, col_names = NULL) {
@@ -80,12 +80,7 @@ fwf_widths <- function(widths, col_names = NULL) {
 #'    Use NA or Inf as last end field when reading a ragged fwf file.
 fwf_positions <- function(start, end, col_names = NULL) {
 
-  # Support for Ragged fwf files. Remove last end element when it is Inf or NA
-  if (is.infinite(end[length(end)]) || is.na(end[length(end)])) {
-    end <- end[-length(end)]
-  }
-
-  stopifnot((length(start)-length(end)) %in% 0:1)
+  stopifnot(length(start) == length(end))
 
   if (is.null(col_names)) {
     col_names <- paste0("X", seq_along(start))

--- a/src/TokenizerFwf.cpp
+++ b/src/TokenizerFwf.cpp
@@ -85,10 +85,10 @@ TokenizerFwf::TokenizerFwf(const std::vector<int>& beginOffset, const std::vecto
 
   // File is assumed to be ragged (last column can have variable width)
   // when the last element of endOffset_ is NA
-  isRagged_ = endOffset_[endOffset_.size()-1L] == NA_INTEGER;
+  isRagged_ = endOffset_[endOffset_.size() - 1L] == NA_INTEGER;
 
   max_ = 0;
-  for (int j = 0; j < (cols_-isRagged_); ++j) {
+  for (int j = 0; j < (cols_ - isRagged_); ++j) {
     if (endOffset_[j] <= beginOffset_[j])
       Rcpp::stop("Begin offset (%i) must be smaller than end offset (%i)",
         beginOffset_[j], endOffset_[j]);

--- a/src/TokenizerFwf.h
+++ b/src/TokenizerFwf.h
@@ -12,7 +12,7 @@ class TokenizerFwf : public Tokenizer {
 
   SourceIterator begin_, curLine_, end_;
   int row_, col_, cols_, max_;
-  bool moreTokens_,isRagged_;
+  bool moreTokens_, isRagged_;
 
 public:
 

--- a/src/TokenizerFwf.h
+++ b/src/TokenizerFwf.h
@@ -12,7 +12,7 @@ class TokenizerFwf : public Tokenizer {
 
   SourceIterator begin_, curLine_, end_;
   int row_, col_, cols_, max_;
-  bool moreTokens_;
+  bool moreTokens_,isRagged_;
 
 public:
 

--- a/tests/testthat/test-read-fwf.R
+++ b/tests/testthat/test-read-fwf.R
@@ -14,8 +14,8 @@ test_that("passing \"\" to read_fwf's 'na' option", {
                c("bar", NA))
 })
 
-test_that("ragged last column silently expanded", {
-  x <- read_fwf("1a\n2ab\n3abc", fwf_widths(c(1, 1)))
+test_that("ragged last column expanded with NA", {
+  x <- read_fwf("1a\n2ab\n3abc", fwf_widths(c(1, NA)))
   expect_equal(x$X2, c("a", "ab", "abc"))
   expect_equal(n_problems(x), 0)
 })
@@ -24,6 +24,39 @@ test_that("ragged last column shrunk with warning", {
   expect_warning(x <- read_fwf("1a\n2ab\n3abc", fwf_widths(c(1, 3))))
   expect_equal(x$X2, c("a", "ab", "abc"))
   expect_equal(n_problems(x), 2)
+})
+
+test_that("read all columns with positions, non ragged", {
+  col_pos <- fwf_positions(c(1,3,6),c(2,5,6))
+  x <- read_fwf('12345A\n67890BBBBBBBBB\n54321C',col_positions = col_pos)
+  expect_equal(x$X3, c("A", "B", "C"))
+  expect_equal(n_problems(x), 0)
+})
+
+test_that("read subset columns with positions", {
+  col_pos <- fwf_positions(c(1,3),c(2,5))
+  x <- read_fwf('12345A\n67890BBBBBBBBB\n54321C',col_positions = col_pos)
+  expect_equal(x$X1, c(12, 67, 54))
+  expect_equal(x$X2, c(345, 890, 321))
+  expect_equal(n_problems(x), 0)
+})
+
+test_that("read columns with positions, ragged", {
+  col_pos <- fwf_positions(c(1,3,6),c(2,5,NA))
+  x <- read_fwf('12345A\n67890BBBBBBBBB\n54321C',col_positions = col_pos)
+  expect_equal(x$X1, c(12, 67, 54))
+  expect_equal(x$X2, c(345, 890, 321))
+  expect_equal(x$X3, c('A', 'BBBBBBBBB', 'C'))
+  expect_equal(n_problems(x), 0)
+})
+
+test_that("read columns with width, ragged", {
+  col_pos <- fwf_widths(c(2,3,NA))
+  x <- read_fwf('12345A\n67890BBBBBBBBB\n54321C',col_positions = col_pos)
+  expect_equal(x$X1, c(12, 67, 54))
+  expect_equal(x$X2, c(345, 890, 321))
+  expect_equal(x$X3, c('A', 'BBBBBBBBB', 'C'))
+  expect_equal(n_problems(x), 0)
 })
 
 # read_table -------------------------------------------------------------------


### PR DESCRIPTION
This pull request should fix items 300 and 326. The current fwf format is kind of broken if you want to read a subset of columns.

Ragged fwf (where the last column width if variable) do exists, but they should be a minority. This implementation assumes ragged fwf only when the last end position is NA, Inf or omitted.

```R
x <- '12345A\n67890BBBBBBBBB\n54321C'

col_names <- c('A','B','C')
start <- c(1,3,6)
end   <- c(2,5,6)

# Read all columns, non Ragged
col_positions <- fwf_positions(start,end,col_names)
df1 <- read_fwf(x,col_positions = col_positions);df1

# Read subset of columns, it works!
col_positions <- fwf_positions(start[1:2],end[1:2],col_names[1:2])
df2 <- read_fwf(x,col_positions = col_positions);df2

# Read Ragged
col_positions <- fwf_positions(start,end[1:2],col_names)
df3 <- read_fwf(x,col_positions = col_positions);df3

# Read Ragged, alternate way
col_positions <- fwf_positions(start,end=c(2,5,Inf),col_names)
df4 <- read_fwf(x,col_positions = col_positions);df4

# Read Ragged alternate way with fwf_widths
col_positions <- fwf_widths(widths = c(2,3,NA),col_names)
df5 <- read_fwf(x,col_positions = col_positions);df5
```