### PR TITLE
Require data.frame input for type_convert()

### DIFF
--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -21,6 +21,7 @@
 #' str(type_convert(df))
 type_convert <- function(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
                          locale = default_locale()) {
+  stopifnot(is.data.frame(df))
   is_character <- vapply(df, is.character, logical(1))
 
   char_cols <- df[is_character]

--- a/tests/testthat/test-type-convert.R
+++ b/tests/testthat/test-type-convert.R
@@ -6,3 +6,8 @@ test_that("missing values removed before guessing col type", {
 
   expect_equal(df2$x, c(NA, 10L))
 })
+
+test_that("requires data.frame input", {
+  not_df <- matrix(letters[1:4], nrow = 2)
+  expect_error(type_convert(not_df))
+})

--- a/tests/testthat/test-write-delim.R
+++ b/tests/testthat/test-write-delim.R
@@ -57,6 +57,6 @@ test_that("roundtrip preserves dates and datetimes", {
   expect_equal(output$y, y)
 })
 
-test_that("fails to create file in non-existent direction", {
+test_that("fails to create file in non-existent directory", {
   expect_error(write_csv(mtcars, file.path(tempdir(), "/x/y")), "Failed to open")
 })


### PR DESCRIPTION
Otherwise, when input is character, the function makes it impressively far before failing with a cryptic message:

``` r
library(readr)
not_df <- matrix(letters[1:12], nrow = 4,
                 dimnames = list(NULL, paste0("V", 1:3)))
type_convert(not_df)
#> Error: `col_names` must be TRUE, FALSE or a character vector
type_convert(not_df, col_names = TRUE)
#> Error in type_convert(not_df, col_names = TRUE): unused argument (col_names = TRUE)
```
Of course it would also be pretty sweet if `type_convert()` accepted a character matrix as input.