### PR TITLE
Subset col_types when there are too many; fixes #371

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,9 @@
 
 * Negative column widths are now allowed in `fwf_widths()` to facilitate
   compatibility with the `widths` argument in `read.fwf()`. (#380, @leeper)
-* `type_covert()` now accepts only `NULL` or a `cols` specification for
+* `type_convert()` now accepts only `NULL` or a `cols` specification for
   `col_types` (#369, @jimhester).
+* If `col_types` is too long, it is subsetted correctly. (#372, @jennybc)
 * `read_file()`, `read_lines()` and `read_csv()` now return empty objects
   rather than signaling an error when run on an empty file (#356, @jimhester).
 

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -152,7 +152,7 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
     if (length(spec$cols) != length(col_names)) {
       warning("Unnamed `col_types` should have the same length as `col_names`. ",
         "Using smaller of the two.", call. = FALSE)
-      n <- min(length(col_names), length(col_types))
+      n <- min(length(col_names), length(spec$cols))
       spec$cols <- spec$cols[seq_len(n)]
       col_names <- col_names[seq_len(n)]
     }

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -110,6 +110,15 @@ test_that("extra columns generates warnings", {
   expect_equal(problems(out4)$expected, "2 columns")
 })
 
+test_that("too few or extra col_types generates warnings", {
+  expect_warning(out1 <- read_csv("v1,v2\n1,2", col_types = "i"))
+  expect_equal(problems(out1)$expected, "1 columns")
+  expect_equal(  problems(out1)$actual, "2 columns")
+
+  expect_warning(out2 <- read_csv("v1,v2\n1,2", col_types = "iii"))
+  expect_equal(ncol(out2), 2)
+})
+
 # read_csv2 ---------------------------------------------------------------
 
 test_that("decimal mark automatically set to ,", {


### PR DESCRIPTION
The result is now what I expect, but seems like there should be problems? I don't know how to fix that.

``` r
(too_many <- read_csv("v1,v2\n1,2", col_types = "iii"))
#> Warning: Unnamed `col_types` should have the same length as `col_names`.
#> Using smaller of the two.
#>   v1 v2
#> 1  1  2
problems(too_many)
#> [1] row      col      expected actual  
#> <0 rows> (or 0-length row.names)
```