### PR TITLE
Fix addition of column names; fixes #373

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # readr 0.2.2.9000
 
+* When column names are insufficient, the added names are numbered correctly and won't be `NA` (#374, @jennybc).
+
 * `parse_time("NA")` works as expected (#398).
 
 * Quick hack to return something instead of NA for missing column names

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -173,7 +173,9 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
     } else if (n_read > n_names) {
       warning("Insufficient `col_names`. Adding ", n_new, " names.",
         call. = FALSE)
-      col_names <- c(col_names, paste0("X", seq_len(n_new) + n_read - 1))
+      tmp <- rep("", length(spec$cols))
+      tmp[!skipped] <- c(col_names, paste0("X", seq_len(n_new) + n_names))
+      col_names <- tmp
     } else {
       col_names2 <- rep("", length(spec$cols))
       col_names2[!skipped] <- col_names

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -18,10 +18,18 @@ test_that("guess col names matches all col types", {
 
 test_that("col_names expanded to col_types with dummy names", {
   expect_warning(
-    out <- col_spec_standardise("1,2,3\n", c("a", "b"), "iii"),
+    out <- col_spec_standardise("1,2,3,4\n", c("a", "b"), "iiii"),
     "Insufficient `col_names`"
   )
-  expect_equal(names(out), c("a", "b", "X3"))
+  expect_equal(names(out), c("a", "b", "X3", "X4"))
+})
+
+test_that("col_names expanded to match col_types, with skipping", {
+  expect_warning(
+    out <- col_spec_standardise(col_types = "c_c", col_names = "a"),
+    "Insufficient `col_names`"
+  )
+  expect_equal(names(out), c("a", "", "X2"))
 })
 
 test_that("col_types expanded to col_names by guessing", {


### PR DESCRIPTION
Before:

``` r
library(readr)
(x <- read_csv("1,2,3,4\n", c("a", "b"), "iiii"))
#> Warning: Insufficient `col_names`. Adding 2 names.
#>   a b X4 X5
#> 1 1 2  3  4
(x <- read_csv("1,2,3\n", "a", "c_c"))
#> Warning: Insufficient `col_names`. Adding 1 names.
#>   a NA
#> 1 1  3
```

After:
```r
load_all(".")
(x <- read_csv("1,2,3,4\n", c("a", "b"), "iiii"))
#> Warning: Insufficient `col_names`. Adding 2 names.
#>   a b X3 X4
#> 1 1 2  3  4
(x <- read_csv("1,2,3\n", "a", "c_c"))
#> Warning: Insufficient `col_names`. Adding 1 names.
#>   a X2
#> 1 1  3
```
