### PR TITLE
Convert negative fwf widths to positive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 # readr 0.2.2.9000
+
+* Negative column widths are now allowed in `fwf_widths()` to facilitate
+  compatibility with the `widths` argument in `read.fwf()`. (#380, @leeper)
+
 * time objects returned by `parse_time()` are now `hms` objects rather than a
   custom `time` class (#409, @jimhester).
 

--- a/R/read_fwf.R
+++ b/R/read_fwf.R
@@ -69,7 +69,7 @@ fwf_empty <- function(file, skip = 0, col_names = NULL) {
 #'    reading a ragged fwf file.
 #' @param col_names Either NULL, or a character vector column names.
 fwf_widths <- function(widths, col_names = NULL) {
-  pos <- cumsum(c(1, widths))
+  pos <- cumsum(c(1, abs(widths)))
 
   fwf_positions(pos[-length(pos)], pos[-1] - 1, col_names)
 }


### PR DESCRIPTION
This is a really simple change that allows someone to specify negative column widths when using `read_fwf()`. To demonstrate the problem here's a comparison of `read.fwf()` versus `read_fwf()` when one wants to skip a column:

```
> read.fwf(fwf_sample, widths = c(5, -1, 4), col.names = letters[c(1,3)])
      a    c
1 12345 7890
2 12345 7890
3 12345 7890
4 12345 7890
5 12345 7890
> read_fwf(fwf_sample, fwf_widths(c(5, -1, 4), letters[1:3]), col_types = cols(a = "i", b = "_", c = "i"))
Error: Begin offset (5) must be smaller than end offset (4)
```

If a user is porting code from `read.fwf()` to readr, they are very likely to have negative column widths. This PR simply converts width to positive values as required by `fwf_widths()`, such that the result of the above is:

```
> read_fwf(fwf_sample, fwf_widths(c(5, -1, 4), letters[1:3]), col_types = cols(a = "i", b = "_", c = "i"))
      a    c
1 12345 7890
2 12345 7890
3 12345 7890
4 12345 7890
5 12345 7890
```