### PR TITLE
Implemented "Truncated division" instead of  "Floored division"

### DIFF
--- a/R/time.R
+++ b/R/time.R
@@ -1,9 +1,9 @@
 #' @export
 format.time <- function(x, ...) {
   x <- as.integer(x)
-  h <- x %/% 3600L
-  m <- (x - h * 3600L) %/% 60L
-  s <- x %% 60L
+  h <- trunc(x / 3600L)
+  m <- abs(x - h * 3600L) %/% 60L
+  s <- abs(x) %% 60L
 
   hms <- paste0(
     format(h, align = "right"), ":",

--- a/R/time.R
+++ b/R/time.R
@@ -1,11 +1,12 @@
 #' @export
 format.time <- function(x, ...) {
-  x <- as.integer(x)
-  h <- trunc(x / 3600L)
-  m <- abs(x - h * 3600L) %/% 60L
-  s <- abs(x) %% 60L
+  x_nosign <- as.integer(abs(x))
+  h <- x_nosign %/% 3600L
+  m <- (x_nosign - h * 3600L) %/% 60L
+  s <- x_nosign %% 60L
 
   hms <- paste0(
+    ifelse(sign(x) == -1, "-", ""),
     format(h, align = "right"), ":",
     sprintf("%02d", m), ":",
     sprintf("%02d", s)


### PR DESCRIPTION
I do not know if it is useful to have `format.time` correctly deal with negative count of seconds (currently it always results in an inflated hh:mm:ss conversion): `format.time(-15300)` returns "-05:45:00" (because `-15300%/%3600L` is rounded to -5) instead of "-04:15:00".
It looks like R %/% arithmetic operator implements "floored division", ie from wikipedia (https://en.wikipedia.org/wiki/Modulo_operation):  

> Donald Knuth[7] described floored division where the quotient is defined by the floor function q = ⌊a/n⌋ and thus according to equation (1) the remainder would have the same sign as the divisor. Due to the floor function, the quotient is always rounded downwards, even if it is already negative.

The pull request implements "truncated division", where the quotient is defined by truncation q = trunc(
a/n).