### PR TITLE
Allow for lowercase and 0/1 logical values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Quick hack to return something instead of NA for missing column names
   (#318)
 
+* `parse_logical()` now accepts `0`, `1` as well as lowercase `t`, `f`, `true`, `false`. 
+
 # readr 0.2.2
 
 * Fix bug when checking empty values for missingness (caused valgrind issue

--- a/src/Collector.cpp
+++ b/src/Collector.cpp
@@ -264,23 +264,23 @@ void CollectorLogical::setValue(int i, const Token& t) {
 
     switch(size) {
     case 1:
-      if (*string.first == 'T') {
+      if (*string.first == 'T' || *string.first == 't' || *string.first == '1') {
         LOGICAL(column_)[i] = 1;
         return;
       }
-      if (*string.first == 'F') {
+      if (*string.first == 'F' || *string.first == 'f' || *string.first == '0') {
         LOGICAL(column_)[i] = 0;
         return;
       }
       break;
     case 4:
-      if (strncmp(string.first, "TRUE", 4) == 0) {
+      if (strncmp(string.first, "TRUE", 4) == 0 || strncmp(string.first, "true", 4) == 0) {
         LOGICAL(column_)[i] = 1;
         return;
       }
       break;
     case 5:
-      if (strncmp(string.first, "FALSE", 5) == 0) {
+      if (strncmp(string.first, "FALSE", 5) == 0 || strncmp(string.first, "false", 5) == 0) {
         LOGICAL(column_)[i] = 0;
         return;
       }
@@ -289,7 +289,7 @@ void CollectorLogical::setValue(int i, const Token& t) {
       break;
     }
 
-    warn(t.row(), t.col(), "T/F/TRUE/FALSE", string);
+    warn(t.row(), t.col(), "1/0/T/F/TRUE/FALSE", string);
     LOGICAL(column_)[i] = NA_LOGICAL;
     return;
   };

--- a/tests/testthat/test-parsing-logical.R
+++ b/tests/testthat/test-parsing-logical.R
@@ -4,8 +4,20 @@ test_that("TRUE and FALSE parsed", {
   expect_equal(parse_logical(c("TRUE", "FALSE")), c(TRUE, FALSE))
 })
 
+test_that("true and false parsed", {
+  expect_equal(parse_logical(c("true", "false")), c(TRUE, FALSE))
+})
+
 test_that("T and F parsed", {
   expect_equal(parse_logical(c("T", "F")), c(TRUE, FALSE))
+})
+
+test_that("t and f parsed", {
+  expect_equal(parse_logical(c("t", "f")), c(TRUE, FALSE))
+})
+
+test_that("1 and 0 parsed", {
+  expect_equal(parse_logical(c("1", "0")), c(TRUE, FALSE))
 })
 
 test_that("other values generate warnings", {


### PR DESCRIPTION
It is not uncommon that boolean values are noted as `0`/`1` or lowercase `true`/`false` in csv.