### PR TITLE
Support parsing year only dates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Quick hack to return something instead of NA for missing column names
   (#318)
+  
+* Add support for parsing years with col_date("%Y") or col_datetime("%Y") 
 
 # readr 0.2.2
 

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -204,7 +204,8 @@ col_guess <- function() {
 #' \enumerate{
 #'   \item Date components are specified with "\%" followed by a letter.
 #'     For example "\%Y" matches a 4 digit year, "\%m", matches a 2 digit
-#'     month and "\%d" matches a 2 digit day.
+#'     month and "\%d" matches a 2 digit day. Month and day default to \code{1},
+#'     (i.e. Jan 1st) if not present, for example if only a year is given.
 #'   \item Whitespace is any sequence of zero or more whitespace characters.
 #'   \item Any other character is matched exactly.
 #' }

--- a/src/DateTime.h
+++ b/src/DateTime.h
@@ -71,6 +71,8 @@ public:
   }
 
   bool validDate() const {
+    if (year_ < 0)
+      return false;
     if (mon_ < 0 || mon_ > 11)
       return false;
     if (day_ < 0 || day_ >= days_in_month())

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -421,8 +421,8 @@ private:
 
   void reset() {
     year_ = -1;
-    mon_ = -1;
-    day_ = -1;
+    mon_ = 0;
+    day_ = 0;
     hour_ = 0;
     min_ = 0;
     sec_ = 0;

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -70,7 +70,7 @@ test_that("failed parsing returns NA", {
 })
 
 test_that("invalid specs returns NA", {
-  expect_warning(x <- parse_datetime("2010-02-02", "%Y-%m-%m"))
+  expect_warning(x <- parse_datetime("2010-02-20", "%Y-%m-%m"))
   expect_equal(is.na(x), TRUE)
   expect_equal(n_problems(x), 1)
 })
@@ -79,6 +79,11 @@ test_that("ISO8601 partial dates are not parsed", {
   expect_equal(n_problems(parse_datetime("20")), 1)
   expect_equal(n_problems(parse_datetime("2001")), 1)
   expect_equal(n_problems(parse_datetime("2001-01")), 1)
+})
+
+test_that("Year only gets parsed", {
+  expect_equal(parse_datetime("2010", "%Y"), ISOdate(2010, 1, 1, 0, tz = "UTC"))
+  expect_equal(parse_datetime("2010-06", "%Y-%m"),ISOdate(2010, 6, 1, 0, tz = "UTC"))
 })
 
 test_that("%p detects AM/PM", {


### PR DESCRIPTION
Support parsing a year-only e.g. `%Y` format:

```r
read_csv("x,y\n2014,2014\n", col_types = list(col_date("%Y"), col_datetime("%Y")))
```

It's a bit of an edge case, but if the user specifically sets the format to `%Y` this should work.