### PR TITLE
Only skip the first line if data includes col_names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # readr 0.2.2.9000
 
+* Fix bug when detecting column types for single row files without headers
+  (#333, @jimhester).
+
 * Fix bug in `read_fwf()`, it will now properly read a subset of columns.
   If the final column is ragged, supply an NA as the final end `fwf_positions`
   or final width `fwf_widths` position (#353,@ghaarsma).
@@ -23,8 +26,6 @@
 
 * `read_delim()` gains a `trim_ws` argument (#312, noamross)
 
-=======
->>>>>>> Updated and appended read_fwf tests and NEWS.md
 # readr 0.2.2
 
 * Fix bug when checking empty values for missingness (caused valgrind issue

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -124,12 +124,12 @@ col_spec_standardise <- function(file, col_names = TRUE, col_types = NULL,
     ds_header <- datasource(file, skip = skip, comment = comment)
     if (col_names) {
       col_names <- guess_header(ds_header, tokenizer, locale)
+      skip <- skip + 1
     } else {
       n <- length(guess_header(ds_header, tokenizer, locale))
       col_names <- paste0("X", seq_len(n))
     }
     guessed_names <- TRUE
-    skip <- skip + 1
   } else if (is.character(col_names)) {
     guessed_names <- FALSE
   } else {

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -49,3 +49,7 @@ test_that("defaults expanded to match names", {
     c = col_character()
   ))
 })
+
+test_that("col_spec_standardise works properly with 1 row inputs and no header columns (#333)", {
+  expect_is(col_spec_standardise("1\n", col_names = FALSE)$X1, "collector_integer")
+})


### PR DESCRIPTION
The skip line was being used even if `col_names = FALSE`, skipping only when `TRUE` fixes the issue.

Fixes #333