### PR TITLE
single '-' or '.' are now parsed as characters rather than numeric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix bug when detecting column types for single row files without headers
   (#333, @jimhester).
+* Fix bug in `collector_guess()`, single '-' or '.' are now parsed as
+  characters rather than numeric (#297, @jimhester).
 
 * Fix bug in `read_fwf()`, it will now properly read a subset of columns.
   If the final column is ragged, supply an NA as the final end `fwf_positions`

--- a/src/QiParsers.h
+++ b/src/QiParsers.h
@@ -51,6 +51,7 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
 
   double sum = 0, denom = 1;
   NumberState state = STATE_INIT;
+  bool seenNumber = false;
 
   Iterator cur = first;
   for(; cur != last; ++cur) {
@@ -61,6 +62,7 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
       } else if (*cur == decimalMark) {
         state = STATE_RHS;
       } else if (*cur >= '0' && *cur <= '9') {
+        seenNumber = true;
         state = STATE_LHS;
         sum = *cur - '0';
       } else {
@@ -73,6 +75,7 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
       } else if (*cur == decimalMark) {
         state = STATE_RHS;
       } else if (*cur >= '0' && *cur <= '9') {
+        seenNumber = true;
         sum *= 10;
         sum += *cur - '0';
       } else if (*cur == '-') {
@@ -88,6 +91,7 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
       } else if (*cur == decimalMark) {
         return false;
       } else if (*cur >= '0' && *cur <= '9') {
+        seenNumber = true;
         denom *= 10;
         sum += (*cur - '0') / denom;
       } else {
@@ -97,14 +101,14 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
     case STATE_FIN:
       last = cur++;
       res = sum;
-      return true;
+      return seenNumber;
     }
   }
 
   // Hit the end of the string, so must be done
   last = cur;
   res = sum;
-  return true;
+  return seenNumber;
 }
 
 

--- a/tests/testthat/test-parsing-numeric.R
+++ b/tests/testthat/test-parsing-numeric.R
@@ -1,4 +1,5 @@
 context("Parsing, numeric")
+es_MX <- locale("es", decimal_mark = ",")
 
 test_that("non-numeric integer/double matches fail", {
   expect_equal(n_problems(parse_double("d")), 1)
@@ -19,6 +20,14 @@ test_that("leading/trailing ws ignored when parsing", {
   expect_equal(read_csv("x\n 1.5\n1.5\n1.5 \n")$x, rep(1.5, 3))
 })
 
+test_that("lone - or decimal marks are not numbers", {
+  expect_equal(collector_guess("-"), "character")
+  expect_equal(collector_guess("."), "character")
+  expect_equal(collector_guess(",", locale = es_MX), "character")
+
+  expect_equal(n_problems(parse_numeric(c(".", "-"))), 2)
+})
+
 
 # Leading zeros -----------------------------------------------------------
 
@@ -29,8 +38,6 @@ test_that("leading zeros are not numbers", {
 })
 
 # Flexible number parsing -------------------------------------------------
-es_MX <- locale("es", decimal_mark = ",")
-
 test_that("col_number only takes first number", {
   expect_equal(parse_number("XYZ 123,000 BLAH 456"), 123000)
 })


### PR DESCRIPTION
Explicitly checking for this case seems like the best option. I played around with editing the DFA in parseNumber but it ended up being more hassle than it was worth.

Fixes #297