### PR TITLE
Properly guess type for numbers with a trailing character

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 # readr 0.2.2.9000
 
+* Fix bug when guessing type for numbers with a trailing character (#316,
+  @jimhester).
+
 * Fix bug when detecting column types for single row files without headers
   (#333, @jimhester).
+
 * Fix bug in `collector_guess()`, single '-' or '.' are now parsed as
   characters rather than numeric (#297, @jimhester).
 

--- a/src/QiParsers.h
+++ b/src/QiParsers.h
@@ -108,7 +108,10 @@ inline bool parseNumber(char decimalMark, char groupingMark, Iterator& first,
   // Hit the end of the string, so must be done
   last = cur;
   res = sum;
-  return seenNumber;
+
+  // Only true if we saw a number and reached the end of the string without
+  // finishing the number
+  return seenNumber && state != STATE_FIN;
 }
 
 

--- a/tests/testthat/test-parsing-numeric.R
+++ b/tests/testthat/test-parsing-numeric.R
@@ -28,6 +28,11 @@ test_that("lone - or decimal marks are not numbers", {
   expect_equal(n_problems(parse_numeric(c(".", "-"))), 2)
 })
 
+test_that("Numbers with trailing characters are parsed as characters", {
+  expect_equal(collector_guess("13T"), "character")
+
+  expect_equal(collector_guess(collector_guess(c("13T","13T","10N"))), "character")
+})
 
 # Leading zeros -----------------------------------------------------------
 


### PR DESCRIPTION
Fixes #316 