### PR TITLE
Add na arguments to parse_date() parse_time() and parse_datetime()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   @jimhester).
 * Fix bug in `parse_date()` constructing dates based on integer vectors rather
   than numeric vectors (#357, @jimhester).
+* Add `na` arguments to `parse_date()` `parse_time()` and `parse_datetime()`
+  (#413, @jimhester).
 
 * Fix bug when detecting column types for single row files without headers
   (#333, @jimhester).

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -36,6 +36,7 @@ collector_find <- function(name) {
 #' @param x Character vector of elements to parse.
 #' @param collector Column specification.
 #' @inheritParams read_delim
+#' @inheritParams tokenizer_delim
 #' @keywords internal
 #' @export
 #' @examples
@@ -266,6 +267,7 @@ col_guess <- function() {
 #'   Unlike \code{\link{strptime}}, the format specification must match
 #'   the complete string.
 #' @inheritParams read_delim
+#' @inheritParams tokenizer_delim
 #' @return A \code{\link{POSIXct}} vector with \code{tzone} attribute set to
 #'   \code{tz}. Elements that could not be parsed (or did not generate valid
 #'   dates) will bes set to \code{NA}, and a warning message will inform
@@ -330,8 +332,8 @@ col_guess <- function() {
 #' parse_datetime("1979-10-14T1010Z", locale = us_central)
 #' # Your current time zone
 #' parse_datetime("1979-10-14T1010", locale = locale(tz = ""))
-parse_datetime <- function(x, format = "", locale = default_locale()) {
-  parse_vector(x, col_datetime(format), locale = locale)
+parse_datetime <- function(x, format = "", na = c("", "NA"), locale = default_locale()) {
+  parse_vector(x, col_datetime(format), na = na, locale = locale)
 }
 
 #' @rdname parse_datetime
@@ -342,8 +344,8 @@ col_datetime <- function(format = "") {
 
 #' @rdname parse_datetime
 #' @export
-parse_date <- function(x, format = "%Y-%m-%d", locale = default_locale()) {
-  parse_vector(x, col_date(format), locale = locale)
+parse_date <- function(x, format = "%Y-%m-%d", na = c("", "NA"), locale = default_locale()) {
+  parse_vector(x, col_date(format), na = na, locale = locale)
 }
 
 #' @rdname parse_datetime
@@ -354,8 +356,8 @@ col_date <- function(format = NULL) {
 
 #' @rdname parse_datetime
 #' @export
-parse_time <- function(x, format = "", locale = default_locale()) {
-  parse_vector(x, col_time(format), locale = locale)
+parse_time <- function(x, format = "", na = c("", "NA"), locale = default_locale()) {
+  parse_vector(x, col_time(format), na = na, locale = locale)
 }
 
 #' @rdname parse_datetime

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -9,15 +9,17 @@
 \alias{parse_time}
 \title{Parse a character vector of dates or date times.}
 \usage{
-parse_datetime(x, format = "", locale = default_locale())
+parse_datetime(x, format = "", na = c("", "NA"),
+  locale = default_locale())
 
 col_datetime(format = "")
 
-parse_date(x, format = "\%Y-\%m-\%d", locale = default_locale())
+parse_date(x, format = "\%Y-\%m-\%d", na = c("", "NA"),
+  locale = default_locale())
 
 col_date(format = NULL)
 
-parse_time(x, format = "", locale = default_locale())
+parse_time(x, format = "", na = c("", "NA"), locale = default_locale())
 
 col_time(format = "")
 }
@@ -31,6 +33,9 @@ col_time(format = "")
 
   Unlike \code{\link{strptime}}, the format specification must match
   the complete string.}
+
+\item{na}{Character vector of strings to use for missing values. Set this
+option to \code{character()} to indicate no missing values.}
 
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
@@ -55,7 +60,8 @@ There are three types of element:
 \enumerate{
   \item Date components are specified with "\%" followed by a letter.
     For example "\%Y" matches a 4 digit year, "\%m", matches a 2 digit
-    month and "\%d" matches a 2 digit day.
+    month and "\%d" matches a 2 digit day. Month and day default to \code{1},
+    (i.e. Jan 1st) if not present, for example if only a year is given.
   \item Whitespace is any sequence of zero or more whitespace characters.
   \item Any other character is matched exactly.
 }

--- a/man/parse_vector.Rd
+++ b/man/parse_vector.Rd
@@ -11,6 +11,9 @@ parse_vector(x, collector, na = c("", "NA"), locale = default_locale())
 
 \item{collector}{Column specification.}
 
+\item{na}{Character vector of strings to use for missing values. Set this
+option to \code{character()} to indicate no missing values.}
+
 \item{locale}{The locale controls defaults that vary from place to place.
 The default locale is US-centric (like R), but you can use
 \code{\link{locale}} to create your own locale that controls things like

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -127,6 +127,17 @@ test_that("parse_date returns a double like as.Date()", {
   expect_typeof(parse_datetime("2001-01-01"), "double")
 })
 
+test_that("parses NA/empty correctly", {
+  expect_equal(parse_datetime(""), POSIXct(NA_real_))
+  expect_equal(parse_date(""), as.Date(NA))
+
+  expect_equal(parse_datetime("NA"), POSIXct(NA_real_))
+  expect_equal(parse_date("NA"), as.Date(NA))
+
+  expect_equal(parse_datetime("TeSt", na = "TeSt"), POSIXct(NA_real_))
+  expect_equal(parse_date("TeSt", na = "TeSt"), as.Date(NA))
+})
+
 # Locales -----------------------------------------------------------------
 
 test_that("locale affects months", {

--- a/tests/testthat/test-parsing-time.R
+++ b/tests/testthat/test-parsing-time.R
@@ -15,4 +15,7 @@ test_that("parses NA/empty correctly", {
   out <- parse_time(c("NA", ""))
   exp <- structure(c(NA_real_, NA_real_), class = "time")
   expect_equal(out, exp)
+
+  expect_equal(parse_time("TeSt", na = "TeSt"),
+    structure(NA_real_, class = "time"))
 })


### PR DESCRIPTION
All of the other parse_* functions already had an na argument they were passing to parse_vector.

Fixes #413 
