### PR TITLE
collector_guess now guesses time formats as well

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,18 @@
 # readr 0.2.2.9000
 
+* The flexible time parser now requires colons between hours and minutes and
+  optional seconds. (#424, @jimhester)
+
+* `collector_guess()` now guesses time formats as well (#384, @jimhester).
+
 * Fix bug when guessing type for numbers with a trailing character (#316,
+  @jimhester).
+
 * Export `collector_guess()` (#377, @jimhester).
 
 * Fix bug when parsing negative number returns a positive value (#308,
   @jimhester).
+
 * Fix bug in `parse_date()` constructing dates based on integer vectors rather
   than numeric vectors (#357, @jimhester).
 * Add `na` arguments to `parse_date()` `parse_time()` and `parse_datetime()`

--- a/src/CollectorGuess.cpp
+++ b/src/CollectorGuess.cpp
@@ -69,6 +69,13 @@ bool isDouble(const std::string& x, LocaleInfo* pLocale) {
   return parseDouble(pLocale->decimalMark_, begin, end, res) && begin == end;
 }
 
+bool isTime(const std::string& x, LocaleInfo* pLocale) {
+  DateTimeParser parser(pLocale);
+
+  parser.setDate(x.c_str());
+  return parser.parseTime();
+}
+
 bool isDate(const std::string& x, LocaleInfo* pLocale) {
   DateTimeParser parser(pLocale);
 
@@ -108,6 +115,8 @@ std::string collectorGuess(CharacterVector input, List locale_) {
     return "double";
   if (canParse(input, isNumber, &locale))
     return "number";
+  if (canParse(input, isTime, &locale))
+    return "time";
   if (canParse(input, isDate, &locale))
     return "date";
   if (canParse(input, isDateTime, &locale))

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -81,7 +81,8 @@ public:
   bool parseTime() {
     if (!consumeInteger(2, &hour_))
       return false;
-    consumeThisChar(':');
+    if (!consumeThisChar(':'))
+      return false;
     if (!consumeInteger(2, &min_))
       return false;
     consumeThisChar(':');

--- a/tests/testthat/test-parsing-time.R
+++ b/tests/testthat/test-parsing-time.R
@@ -2,11 +2,9 @@ context("Parsing, time")
 
 test_that("default format captures cases", {
   late_night <- structure(22 * 3600 + 20 * 60, class = "time")
-  expect_equal(parse_time("2220"), late_night)
   expect_equal(parse_time("22:20"), late_night)
   expect_equal(parse_time("10:20 pm"), late_night)
 
-  expect_equal(parse_time("222005"), late_night + 5)
   expect_equal(parse_time("22:20:05"), late_night + 5)
   expect_equal(parse_time("10:20:05 pm"), late_night + 5)
 })
@@ -18,4 +16,14 @@ test_that("parses NA/empty correctly", {
 
   expect_equal(parse_time("TeSt", na = "TeSt"),
     structure(NA_real_, class = "time"))
+})
+
+test_that("times are guessed as expected", {
+  expect_equal(collector_guess("12:01"), "time")
+
+  expect_equal(
+    collector_guess("12:01:01"), "time")
+
+  expect_equal(
+    collector_guess(c("04:00:00", "04:30:00", "14:00:22")), "time")
 })


### PR DESCRIPTION
One thing to note with this is the default time format is `%H:%M`, so the examples in the issue are still going to be guessed as dates unless they change the `time_format` in the locale (as is done in the tests).

I don't know if we should change the default time format to `%H:%M:%S` or not.

Fixes #384 