### PR TITLE
WIP: parse_deparsed implementation

### DIFF
--- a/R/collectors.R
+++ b/R/collectors.R
@@ -68,6 +68,7 @@ parse_vector <- function(x, collector, na = c("", "NA"), locale = default_locale
 #' parse_double(c("1", "2", "3.123"))
 #' parse_factor(c("a", "b"), letters)
 #' parse_number("$1,123,456.00")
+#' parse_deparsed(c("c(1, 2, 3)", paste(collapse = "", deparse(head(iris)))))
 #'
 #' # Use locale to override default decimal and grouping marks
 #' es_MX <- locale("es", decimal_mark = ",")
@@ -364,4 +365,16 @@ parse_time <- function(x, format = "", na = c("", "NA"), locale = default_locale
 #' @export
 col_time <- function(format = "") {
   collector("time", format = format)
+}
+
+#' @rdname collector
+#' @export
+col_deparsed <- function() {
+  collector("deparsed")
+}
+
+#' @rdname collector
+#' @export
+parse_deparsed <- function(x, na = c("", "NA"), locale = default_locale()) {
+  parse_vector_(x, col_deparsed(), na = na, locale = locale)
 }

--- a/src/Collector.h
+++ b/src/Collector.h
@@ -235,6 +235,19 @@ public:
   }
 };
 
+// Deparsed ---------------------------------------------------------------------
+
+class CollectorDeparsed : public Collector {
+public:
+  CollectorDeparsed():
+    Collector(Rcpp::List()){}
+  void setValue(int i, const Token& t);
+
+    Rcpp::RObject vector() {
+       return column_;
+    }
+};
+
 
 // Helpers ---------------------------------------------------------------------
 

--- a/tests/testthat/test-parsing-deparsed.R
+++ b/tests/testthat/test-parsing-deparsed.R
@@ -1,0 +1,13 @@
+context("Parsing, deparsed")
+
+test_that("parsing failures fail", {
+  expect_error(parse_deparsed("list(1"))
+  expect_error(parse_deparsed("{c(1)"))
+})
+
+test_that("parsing evaluates the expressions", {
+  t1 <- paste(collapse = "", deparse(head(iris)))
+  expect_equal(parse_deparsed(c("c(1, 2, 3)", t1)),
+      list(c(1, 2, 3),
+        head(iris)))
+})


### PR DESCRIPTION
I still need to do the deparsing when writing to a file, but wanted to get any comments about this end first, it seems to work well. I am not sure if missing values should return `NULL` or `NA`, thoughts?

``` r
deparse2 <- function(x) paste(collapse = "", deparse(x))
parse_deparsed(c(deparse2(head(mtcars)), deparse2(head(iris))))
#> [[1]]
#>                    mpg cyl disp  hp drat    wt  qsec vs am gear carb
#> Mazda RX4         21.0   6  160 110 3.90 2.620 16.46  0  1    4    4
#> Mazda RX4 Wag     21.0   6  160 110 3.90 2.875 17.02  0  1    4    4
#> Datsun 710        22.8   4  108  93 3.85 2.320 18.61  1  1    4    1
#> Hornet 4 Drive    21.4   6  258 110 3.08 3.215 19.44  1  0    3    1
#> Hornet Sportabout 18.7   8  360 175 3.15 3.440 17.02  0  0    3    2
#> Valiant           18.1   6  225 105 2.76 3.460 20.22  1  0    3    1
#> 
#> [[2]]
#>   Sepal.Length Sepal.Width Petal.Length Petal.Width Species
#> 1          5.1         3.5          1.4         0.2  setosa
#> 2          4.9         3.0          1.4         0.2  setosa
#> 3          4.7         3.2          1.3         0.2  setosa
#> 4          4.6         3.1          1.5         0.2  setosa
#> 5          5.0         3.6          1.4         0.2  setosa
#> 6          5.4         3.9          1.7         0.4  setosa
```