### PR TITLE
Return empty objects rather than signaling an error on an empty file.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
   compatibility with the `widths` argument in `read.fwf()`. (#380, @leeper)
 * `type_covert()` now accepts only `NULL` or a `cols` specification for
   `col_types` (#369, @jimhester).
+* `read_file()`, `read_lines()` and `read_csv()` now return empty objects
+  rather than signaling an error when run on an empty file (#356, @jimhester).
 
 * time objects returned by `parse_time()` are now `hms` objects rather than a
   custom `time` class (#409, @jimhester).

--- a/R/input.R
+++ b/R/input.R
@@ -6,6 +6,10 @@
 #' @examples
 #' read_file(file.path(R.home(), "COPYING"))
 read_file <- function(file, locale = default_locale()) {
+  if (empty_file(file)) {
+    return("")
+  }
+
   ds <- datasource(file)
   read_file_(ds, locale)
 }

--- a/R/read_delim.R
+++ b/R/read_delim.R
@@ -153,6 +153,9 @@ read_delimited <- function(file, tokenizer, col_names = TRUE, col_types = NULL,
   if (is.connection(file)) {
     data <- read_connection(file)
   } else {
+    if (empty_file(file)) {
+       return(tibble::data_frame())
+    }
     data <- file
   }
 

--- a/R/read_lines.R
+++ b/R/read_lines.R
@@ -15,6 +15,9 @@
 read_lines <- function(file, skip = 0, n_max = -1L,
                        locale = default_locale(),
                        progress = interactive()) {
+  if (empty_file(file)) {
+    return(character())
+  }
   ds <- datasource(file, skip = skip)
   read_lines_(ds, locale_ = locale, n_max = n_max, progress = progress)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,3 +7,7 @@ isFALSE <- function(x) identical(x, FALSE)
 is.connection <- function(x) inherits(x, "connection")
 
 `%||%` <- function(a, b) if (is.null(a)) b else a
+
+empty_file <- function(x) {
+  return(is.character(x) && file.exists(x) && file.info(x, extra_cols = FALSE)$size == 0)
+}

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -22,7 +22,7 @@ public:
       mr_ = boost::interprocess::mapped_region(fm_,
         boost::interprocess::read_only);
     } catch(boost::interprocess::interprocess_exception& e) {
-      Rcpp::stop("Cannot read file %s", path) ;
+      Rcpp::stop("Cannot read file %s: %s", path, e.what());
     }
 
     begin_ = static_cast<char*>(mr_.get_address());

--- a/tests/testthat/test-read-csv.R
+++ b/tests/testthat/test-read-csv.R
@@ -183,3 +183,6 @@ test_that("skip respects comments", {
   expect_equal(read_x(comment = "#", skip = 1), c("c"))
 })
 
+test_that("read_csv returns an empty data.frame on an empty file", {
+   expect_equal(read_csv("empty-file"), tibble::data_frame())
+})

--- a/tests/testthat/test-read-file.R
+++ b/tests/testthat/test-read-file.R
@@ -56,3 +56,7 @@ test_that("read_file works via https on gz file", {
   url <- "https://raw.githubusercontent.com/hadley/readr/master/tests/testthat/eol-cr.txt.gz"
   expect_equal(read_file(url), eol_cr_text)
 })
+
+test_that("read_file returns \"\" on an empty file", {
+   expect_equal(read_file("empty-file"), "")
+})

--- a/tests/testthat/test-read-lines.R
+++ b/tests/testthat/test-read-lines.R
@@ -4,3 +4,7 @@ test_that("read_lines respects encoding", {
   x <- read_lines("enc-iso-8859-1.txt", locale = locale(encoding = "ISO-8859-1"))
   expect_equal(x, c("fran\u00e7ais", "\u00e9l\u00e8ve"))
 })
+
+test_that("read_lines returns an empty character vector on an empty file", {
+   expect_equal(read_lines("empty-file"), character())
+})


### PR DESCRIPTION
I did the file tests in the R side as I didn't think it was worth pulling in the needed Boost headers to do the equivalent test for an empty file.

Fixes #356