### PR TITLE
type_covert now accepts only NULL or a cols specification for col_types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 * Negative column widths are now allowed in `fwf_widths()` to facilitate
   compatibility with the `widths` argument in `read.fwf()`. (#380, @leeper)
+* `type_covert()` now accepts only `NULL` or a `cols` specification for
+  `col_types` (#369, @jimhester).
 
 * time objects returned by `parse_time()` are now `hms` objects rather than a
   custom `time` class (#409, @jimhester).

--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -5,6 +5,19 @@
 #' then let readr take another stab at parsing it.
 #'
 #' @param df A data frame.
+#' @param col_types One of \code{NULL}, a \code{\link{cols}} specification, or
+#'   a string. See \code{vignette("column-types")} for more details.
+#'
+#'   If \code{NULL}, all column types will be imputed from the first 1000 rows
+#'   on the input. This is convenient (and fast), but not robust. If the
+#'   imputation fails, you'll need to supply the correct types yourself.
+#'
+#'   If a column specification created by \code{\link{cols}}, it must contain
+#'   one "\code{\link{collector}}" for each column. If you only want to read a
+#'   subset of the columns, use \code{\link{cols_only}}.
+#'
+#'   Unlike other functions \code{type_convert} does not allow character
+#'   specificatinos of \code{col_types}.
 #' @inheritParams tokenizer_delim
 #' @inheritParams read_delim
 #' @export
@@ -29,6 +42,12 @@ type_convert <- function(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
     x[x %in% na] <- NA
     collector_guess(x, locale)
   })
+
+  if (is.character(col_types)) {
+    stop("`col_types` must be `NULL` or a `cols` specification for `type_convert()`.",
+      call. = FALSE)
+  }
+
   col_types <- col_spec_standardise(
     col_types = col_types,
     col_names = names(char_cols),

--- a/man/type_convert.Rd
+++ b/man/type_convert.Rd
@@ -21,11 +21,8 @@ type_convert(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
   one "\code{\link{collector}}" for each column. If you only want to read a
   subset of the columns, use \code{\link{cols_only}}.
 
-  Alternatively, you can use a compact string representation where each
-  character represents one column:
-  c = character, i = integer, n = number, d = double,
-  l = logical, D = date, T = date time, t = time, ? = guess, or
-  \code{_}/\code{-} to skip the column.}
+  Unlike other functions \code{type_convert} does not allow character
+  specificatinos of \code{col_types}.}
 
 \item{na}{Character vector of strings to use for missing values. Set this
 option to \code{character()} to indicate no missing values.}

--- a/tests/testthat/test-type-convert.R
+++ b/tests/testthat/test-type-convert.R
@@ -11,3 +11,7 @@ test_that("requires data.frame input", {
   not_df <- matrix(letters[1:4], nrow = 2)
   expect_error(type_convert(not_df), "is.data.frame")
 })
+
+test_that("character specifications of col_types not allowed", {
+  expect_error(type_convert(mtcars, col_types = "dididddiiii"), "must be `NULL` or a `cols` specification")
+})


### PR DESCRIPTION
Another alternative would be to subset the col_types with the is_character logical vector as is already done for the data.frame and col_names. Not sure which way would be more useful to people.

e.g. a diff from this PR

```diff
diff --git a/R/type_convert.R b/R/type_convert.R
index 3a46932..bbd5c6c 100644
--- a/R/type_convert.R
+++ b/R/type_convert.R
@@ -44,8 +44,7 @@ type_convert <- function(df, col_types = NULL, na = c("", "NA"), trim_ws = TRUE,
   })

   if (is.character(col_types)) {
-    stop("`col_types` must be `NULL` or a `cols` specification for `type_convert()`.",
-      call. = FALSE)
+    col_types <- paste(collapse = "", substring(col_types, which(is_character), which(is_character)))
   }

   col_types <- col_spec_standardise(
```

Fixes #369