### PR TITLE
save results from default_locale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # readr 0.2.2.9000
 
 * Supports reading into long vectors (#309, @jimhester).
+* `default_locale()` now sets the default locale in `readr.default_locale`
+  rather than regenerating it for each call. (#416, @jimhester).
 
 * Printing of double values now uses an
   [implementation](https://github.com/juj/MathGeoLib/blob/master/src/Math/grisu3.c)

--- a/R/locale.R
+++ b/R/locale.R
@@ -90,11 +90,8 @@ print.locale <- function(x, ...) {
 default_locale <- function() {
   loc <- getOption("readr.default_locale")
   if (is.null(loc)) {
-    return(locale())
-  }
-
-  if (interactive()) {
-    message("Using non-default locale")
+    loc <- locale()
+    options("readr.default_locale" = loc)
   }
 
   loc


### PR DESCRIPTION
Fixes #416 

This seemed a more light weight solution than actually using the memoise package. Because subsequent calls will have the option set I had to remove the message as it was no longer informative or accurate.