### PR TITLE
Parse doubles with boost::spirit::qi::long_double

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # readr 0.2.2.9000
 
+* Parse doubles with `boost::spirit::qi::long_double` to work around a bug in the
+  spirit library when parsing large numbers (#412, @jimhester).
+
 * Supports reading into long vectors (#309, @jimhester).
 * `default_locale()` now sets the default locale in `readr.default_locale`
   rather than regenerating it for each call. (#416, @jimhester).

--- a/src/QiParsers.h
+++ b/src/QiParsers.h
@@ -19,10 +19,10 @@ inline bool parseDouble(const char decimalMark, Iterator& first, Iterator& last,
 
   if (decimalMark == '.') {
     return boost::spirit::qi::parse(first, last,
-      boost::spirit::qi::double_, res);
+      boost::spirit::qi::long_double, res);
   } else if (decimalMark == ',') {
     return boost::spirit::qi::parse(first, last,
-      boost::spirit::qi::real_parser<double, DecimalCommaPolicy>(), res);
+      boost::spirit::qi::real_parser<long double, DecimalCommaPolicy>(), res);
   } else {
     return false;
   }

--- a/tests/testthat/test-parsing-numeric.R
+++ b/tests/testthat/test-parsing-numeric.R
@@ -31,7 +31,7 @@ test_that("lone - or decimal marks are not numbers", {
 test_that("Numbers with trailing characters are parsed as characters", {
   expect_equal(collector_guess("13T"), "character")
 
-  expect_equal(collector_guess(collector_guess(c("13T","13T","10N"))), "character")
+  expect_equal(collector_guess(collector_guess(c("13T", "13T", "10N"))), "character")
 })
 
 # Leading zeros -----------------------------------------------------------
@@ -82,4 +82,16 @@ test_that("negative numbers return negative values", {
   expect_equal(parse_number("-2"), -2)
 
   expect_equal(parse_number("-100,000.00"), -100000)
+})
+
+# Large numbers -------------------------------------------------------------
+
+test_that("large numbers are parsed properly", {
+  expect_equal(parse_double("100000000000000000000"), 1e20)
+
+  expect_equal(parse_double("1267650600228229401496703205376"), 1.267650600228229401496703205376e+30)
+
+  expect_equal(parse_double("100000000000000000000", locale = es_MX), 1e20)
+
+  expect_equal(parse_double("1267650600228229401496703205376", locale = es_MX), 1.267650600228229401496703205376e+30)
 })


### PR DESCRIPTION
This works around an unaddressed spirit regression
(https://svn.boost.org/trac/boost/ticket/11608).

Fixes #412 

I did some benchmarks and there was no performance regressions when parsing a large file of doubles.

Note the numbers being tested are both representable as regular doubles, the `double_` parser is just parsing them improperly.