### PR TITLE
Check for BOM when converting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # readr 0.2.2.9000
+* Skip Unicode byte order markers if they exist (#263, @jimhester).
 
 * Supports reading into long vectors (#309, @jimhester).
+
 * `default_locale()` now sets the default locale in `readr.default_locale`
   rather than regenerating it for each call. (#416, @jimhester).
 

--- a/src/Source.h
+++ b/src/Source.h
@@ -47,6 +47,57 @@ public:
     return cur;
   }
 
+  static const char* skipBom(const char* begin, const char* end) {
+
+    /* Unicode Byte Order Marks
+       https://en.wikipedia.org/wiki/Byte_order_mark#Representations_of_byte_order_marks_by_encoding
+
+       00 00 FE FF: UTF-32BE
+       FF FE 00 00: UTF-32LE
+       FE FF:       UTF-16BE
+       FF FE:       UTF-16LE
+       EF BB BF:    UTF-8
+   */
+
+    switch(begin[0]) {
+      // UTF-32BE
+      case '\x00':
+        if (end - begin >= 4 && begin[1] == '\x00' && begin[2] == '\xFE' && begin[3] == '\xFF') {
+          return begin + 4;
+        }
+        break;
+
+      // UTF-8
+      case '\xEF':
+        if (end - begin >= 3 && begin[1] == '\xBB' && begin[2] == '\xBF') {
+          return begin + 3;
+        }
+        break;
+
+      // UTF-16BE
+      case '\xfe':
+        if (end - begin >= 2 && begin[1] == '\xff') {
+          return begin + 2;
+        }
+        break;
+
+      case '\xff':
+        if (end - begin >= 2 && begin[1] == '\xfe') {
+
+          // UTF-32 LE
+          if (end - begin >= 4 && begin[2] == '\x00' && begin[3] == '\x00') {
+            return begin + 4;
+          }
+
+          // UTF-16 LE
+          return begin + 2;
+        }
+        break;
+    }
+    return begin;
+  }
+
+
   static SourcePtr create(Rcpp::List spec);
 
 private:
@@ -59,5 +110,3 @@ private:
 };
 
 #endif
-
-

--- a/src/Source.h
+++ b/src/Source.h
@@ -52,51 +52,31 @@ public:
     /* Unicode Byte Order Marks
        https://en.wikipedia.org/wiki/Byte_order_mark#Representations_of_byte_order_marks_by_encoding
 
-       00 00 FE FF: UTF-32BE
-       FF FE 00 00: UTF-32LE
-       FE FF:       UTF-16BE
-       FF FE:       UTF-16LE
        EF BB BF:    UTF-8
+       FF FE 00 00: UTF-32LE
+       FF FE:       UTF-16LE
+       FE FF:       UTF-16BE
+       00 00 FE FF: UTF-32BE
    */
+    boost::iterator_range<const char*> haystack(begin, end);
 
-    switch(begin[0]) {
-      // UTF-32BE
-      case '\x00':
-        if (end - begin >= 4 && begin[1] == '\x00' && begin[2] == '\xFE' && begin[3] == '\xFF') {
-          return begin + 4;
-        }
-        break;
-
-      // UTF-8
-      case '\xEF':
-        if (end - begin >= 3 && begin[1] == '\xBB' && begin[2] == '\xBF') {
-          return begin + 3;
-        }
-        break;
-
-      // UTF-16BE
-      case '\xfe':
-        if (end - begin >= 2 && begin[1] == '\xff') {
-          return begin + 2;
-        }
-        break;
-
-      case '\xff':
-        if (end - begin >= 2 && begin[1] == '\xfe') {
-
-          // UTF-32 LE
-          if (end - begin >= 4 && begin[2] == '\x00' && begin[3] == '\x00') {
-            return begin + 4;
-          }
-
-          // UTF-16 LE
-          return begin + 2;
-        }
-        break;
+    if (boost::starts_with(haystack, "\xEF\xBB\xBF")) {
+      return begin + 3;
+    }
+    if (boost::starts_with(haystack, "\xFF\xFE\x00\x00")) {
+      return begin + 4;
+    }
+    if (boost::starts_with(haystack, "\xFF\xFE")) {
+      return begin + 2;
+    }
+    if (boost::starts_with(haystack, "\xFE\xFF")) {
+      return begin + 2;
+    }
+    if (boost::starts_with(haystack, "\x00\x00\xFE\xFF")) {
+      return begin + 4;
     }
     return begin;
   }
-
 
   static SourcePtr create(Rcpp::List spec);
 

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -28,6 +28,9 @@ public:
     begin_ = static_cast<char*>(mr_.get_address());
     end_ = begin_ + mr_.get_size();
 
+    // Skip byte order mark, if needed
+    begin_ = skipBom(begin_, end_);
+
     // Skip lines, if needed
     begin_ = skipLines(begin_, end_, skip, comment);
   }

--- a/src/SourceRaw.h
+++ b/src/SourceRaw.h
@@ -16,6 +16,9 @@ public:
     begin_ = (const char*) RAW(x);
     end_ = (const char*) RAW(x) + Rf_xlength(x);
 
+    // Skip byte order mark, if needed
+    begin_ = skipBom(begin_, end_);
+
     // Skip lines, if needed
     begin_ = skipLines(begin_, end_, skip, comment);
   }

--- a/src/SourceString.h
+++ b/src/SourceString.h
@@ -17,6 +17,9 @@ public:
     begin_ = CHAR(string_);
     end_ = begin_ + Rf_xlength(string_);
 
+    // Skip byte order mark, if needed
+    begin_ = skipBom(begin_, end_);
+
     // Skip lines, if needed
     begin_ = skipLines(begin_, end_, skip, comment);
   }

--- a/tests/testthat/test-parsing-character.R
+++ b/tests/testthat/test-parsing-character.R
@@ -28,3 +28,64 @@ test_that("locale encoding affects parsing", {
   as_raw <- function(x) lapply(x, charToRaw)
   expect_identical(as_raw(x), as_raw(z))
 })
+
+test_that("Unicode Byte order marks are stripped from output", {
+
+  # UTF-8
+  expect_equal(
+    charToRaw(read_lines(
+      as.raw(c(0xef, 0xbb, 0xbf, # BOM
+          0x41, # A
+          0x0A # newline
+          )))),
+    as.raw(0x41))
+
+  # UTF-16 Big Endian
+  expect_equal(
+    charToRaw(read_lines(
+      as.raw(c(0xfe, 0xff, # BOM
+          0x41, # A
+          0x0A # newline
+          )))),
+    as.raw(0x41))
+
+  # UTF-16 Little Endian
+  expect_equal(
+    charToRaw(read_lines(
+      as.raw(c(0xff, 0xfe, # BOM
+          0x41, # A
+          0x0A # newline
+          )))),
+    as.raw(0x41))
+
+  # UTF-32 Big Endian
+  expect_equal(
+    charToRaw(read_lines(
+      as.raw(c(0x00, 0x00, 0xfe, 0xff, # BOM
+          0x41, # A
+          0x0A # newline
+          )))),
+    as.raw(0x41))
+
+  # UTF-32 Little Endian
+  expect_equal(
+    charToRaw(read_lines(
+      as.raw(c(0xff, 0xfe, 0x00, 0x00, # BOM
+          0x41, # A
+          0x0A # newline
+          )))),
+    as.raw(0x41))
+
+  # Vectors shorter than the BOM are handled safely
+  expect_equal(charToRaw(read_lines(
+        as.raw(c(0xef, 0xbb)))),
+    as.raw(c(0xef, 0xbb)))
+
+  expect_equal(charToRaw(read_lines(
+        as.raw(c(0xfe)))),
+    as.raw(c(0xfe)))
+
+  expect_equal(charToRaw(read_lines(
+        as.raw(c(0xff)))),
+    as.raw(c(0xff)))
+})


### PR DESCRIPTION
This works for the test case, the main issue is it really only needs to check for this at the beginning of the file (if it is a UTF-8 file). I am still trying to figure out the best place to put this logic, suggestions welcome!

Fixes #263 