### PR TITLE
Make defaults consistent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # readr 0.2.2.9000
 
+* `%y` and `%Y` are now stricter and require 2 or 4 characters respectively.
+
+* If omitted `col_date()` and `col_time()` (and `parse_date()` and 
+  `parse_time()`) use the date and time formats specified in the locale.
+  
+* The default `date_format` and `time_format`s are `%AD` and `%AT` respectively.
+  These are "automatic" date and time parsers that are moderately flexible.
+  The automatic date parser is somewhat flexible than it used to be - it 
+  requires a four digit year, and only accepts `-` and `/` as separators (#442).
+
 * Missing colum name names are now given a default name (`X2`, `X7` etc) (#318).
   Duplicated column names are now deduplicated. Both changes generate a warning;
   to suppress it supply explicit `col_names` (setting skip = 1 if needed).

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -263,7 +263,7 @@ col_factor <- function(levels, ordered = FALSE) {
 #' }
 #'
 #' @param x A character vector of dates to parse.
-#' @param format A format specification, as described below. If omitted,
+#' @param format A format specification, as described below. If set to "",
 #'   parses dates according to the ISO8601 specification (with caveats,
 #'   as described below). Times are parsed like ISO8601 times, but also
 #'   accept an optional am/pm specification.
@@ -343,7 +343,7 @@ parse_datetime <- function(x, format = "", na = c("", "NA"), locale = default_lo
 
 #' @rdname parse_datetime
 #' @export
-parse_date <- function(x, format = "%Y-%m-%d", na = c("", "NA"), locale = default_locale()) {
+parse_date <- function(x, format = "", na = c("", "NA"), locale = default_locale()) {
   parse_vector(x, col_date(format), na = na, locale = locale)
 }
 
@@ -361,7 +361,7 @@ col_datetime <- function(format = "") {
 
 #' @rdname parse_datetime
 #' @export
-col_date <- function(format = NULL) {
+col_date <- function(format = "") {
   collector("date", format = format)
 }
 

--- a/R/collectors.R
+++ b/R/collectors.R
@@ -183,6 +183,7 @@ col_guess <- function() {
 #' @rdname parse_guess
 #' @export
 guess_parser <- function(x, locale = default_locale()) {
+  stopifnot(is.locale(locale))
   collectorGuess(x, locale)
 }
 
@@ -241,6 +242,8 @@ col_factor <- function(levels, ordered = FALSE) {
 #'   \item Non-digits: "\%." skips one non-digit character,
 #'     "\%+" skips one or more non-digit characters,
 #'     "\%*" skips any number of non-digits characters.
+#'   \item Automatic parsers: "\%AD" parses with a flexible YMD parser,
+#'      "\%AT" parses with a flexible HMS parser.
 #'   \item Shortcuts: "\%D" = "\%m/\%d/\%y",  "\%F" = "\%Y-\%m-\%d",
 #'       "\%R" = "\%H:\%M", "\%T" = "\%H:\%M:\%S",  "\%x" = "\%y/\%m/\%d".
 #' }
@@ -264,9 +267,8 @@ col_factor <- function(levels, ordered = FALSE) {
 #'
 #' @param x A character vector of dates to parse.
 #' @param format A format specification, as described below. If set to "",
-#'   parses dates according to the ISO8601 specification (with caveats,
-#'   as described below). Times are parsed like ISO8601 times, but also
-#'   accept an optional am/pm specification.
+#'   date times are parsed as ISO8601, dates and times used the date and
+#'   time formats specified in the \code{\link{locale}}.
 #'
 #'   Unlike \code{\link{strptime}}, the format specification must match
 #'   the complete string.

--- a/R/locale.R
+++ b/R/locale.R
@@ -39,7 +39,7 @@
 #' # South American locale
 #' locale("es", decimal_mark = ",")
 locale <- function(date_names = "en",
-                   date_format = "%Y%.%m%.%d", time_format = "%H:%M",
+                   date_format = "%AD", time_format = "%AT",
                    decimal_mark = ".", grouping_mark = ",",
                    tz = "UTC", encoding = "UTF-8",
                    asciify = FALSE) {
@@ -79,6 +79,8 @@ locale <- function(date_names = "en",
     class = "locale"
   )
 }
+
+is.locale <- function(x) inherits(x, "locale")
 
 #' @export
 print.locale <- function(x, ...) {

--- a/man/locale.Rd
+++ b/man/locale.Rd
@@ -5,9 +5,9 @@
 \alias{locale}
 \title{Create locales}
 \usage{
-locale(date_names = "en", date_format = "\%Y\%.\%m\%.\%d",
-  time_format = "\%H:\%M", decimal_mark = ".", grouping_mark = ",",
-  tz = "UTC", encoding = "UTF-8", asciify = FALSE)
+locale(date_names = "en", date_format = "\%AD", time_format = "\%AT",
+  decimal_mark = ".", grouping_mark = ",", tz = "UTC",
+  encoding = "UTF-8", asciify = FALSE)
 
 default_locale()
 }

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -26,9 +26,8 @@ col_time(format = "")
 \item{x}{A character vector of dates to parse.}
 
 \item{format}{A format specification, as described below. If set to "",
-  parses dates according to the ISO8601 specification (with caveats,
-  as described below). Times are parsed like ISO8601 times, but also
-  accept an optional am/pm specification.
+  date times are parsed as ISO8601, dates and times used the date and
+  time formats specified in the \code{\link{locale}}.
 
   Unlike \code{\link{strptime}}, the format specification must match
   the complete string.}
@@ -81,6 +80,8 @@ There are three types of element:
   \item Non-digits: "\%." skips one non-digit character,
     "\%+" skips one or more non-digit characters,
     "\%*" skips any number of non-digits characters.
+  \item Automatic parsers: "\%AD" parses with a flexible YMD parser,
+     "\%AT" parses with a flexible HMS parser.
   \item Shortcuts: "\%D" = "\%m/\%d/\%y",  "\%F" = "\%Y-\%m-\%d",
       "\%R" = "\%H:\%M", "\%T" = "\%H:\%M:\%S",  "\%x" = "\%y/\%m/\%d".
 }

--- a/man/parse_datetime.Rd
+++ b/man/parse_datetime.Rd
@@ -12,21 +12,20 @@
 parse_datetime(x, format = "", na = c("", "NA"),
   locale = default_locale())
 
-parse_date(x, format = "\%Y-\%m-\%d", na = c("", "NA"),
-  locale = default_locale())
+parse_date(x, format = "", na = c("", "NA"), locale = default_locale())
 
 parse_time(x, format = "", na = c("", "NA"), locale = default_locale())
 
 col_datetime(format = "")
 
-col_date(format = NULL)
+col_date(format = "")
 
 col_time(format = "")
 }
 \arguments{
 \item{x}{A character vector of dates to parse.}
 
-\item{format}{A format specification, as described below. If omitted,
+\item{format}{A format specification, as described below. If set to "",
   parses dates according to the ISO8601 specification (with caveats,
   as described below). Times are parsed like ISO8601 times, but also
   accept an optional am/pm specification.

--- a/src/Collector.cpp
+++ b/src/Collector.cpp
@@ -100,8 +100,7 @@ void CollectorDate::setValue(int i, const Token& t) {
     std::string std_string(string.first, string.second);
 
     parser_.setDate(std_string.c_str());
-    bool res = (format_ == "") ? parser_.parseISO8601()
-      : parser_.parse(format_);
+    bool res = (format_ == "") ? parser_.parseLocaleDate() : parser_.parse(format_);
 
     if (!res) {
       warn(t.row(), t.col(), "date like " +  format_, std_string);
@@ -337,7 +336,7 @@ void CollectorTime::setValue(int i, const Token& t) {
     std::string std_string(string.first, string.second);
 
     parser_.setDate(std_string.c_str());
-    bool res = (format_ == "") ? parser_.parseTime() : parser_.parse(format_);
+    bool res = (format_ == "") ? parser_.parseLocaleTime() : parser_.parse(format_);
 
     if (!res) {
       warn(t.row(), t.col(), "time like " +  format_, std_string);

--- a/src/CollectorGuess.cpp
+++ b/src/CollectorGuess.cpp
@@ -73,14 +73,14 @@ bool isTime(const std::string& x, LocaleInfo* pLocale) {
   DateTimeParser parser(pLocale);
 
   parser.setDate(x.c_str());
-  return parser.parseTime();
+  return parser.parseLocaleTime();
 }
 
 bool isDate(const std::string& x, LocaleInfo* pLocale) {
   DateTimeParser parser(pLocale);
 
   parser.setDate(x.c_str());
-  return parser.parse(pLocale->dateFormat_);
+  return parser.parseLocaleDate();
 }
 
 static bool isDateTime(const std::string& x, LocaleInfo* pLocale) {

--- a/src/DateTimeParser.h
+++ b/src/DateTimeParser.h
@@ -77,6 +77,14 @@ public:
     return isComplete();
   }
 
+  bool parseLocaleTime() {
+    return parse(pLocale_->timeFormat_);
+  }
+
+  bool parseLocaleDate() {
+    return parse(pLocale_->dateFormat_);
+  }
+
   // A flexible time parser for the most common formats
   bool parseTime() {
     if (!consumeInteger(2, &hour_))

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -134,8 +134,8 @@ test_that("print(col_spec) works with dates", {
     regex_escape(
 "cols(
   a = col_date(format = \"%Y-%m-%d\"),
-  b = col_date(format = NULL),
-  c = col_date(format = NULL)
+  b = col_date(format = \"\"),
+  c = col_date(format = \"\")
 )"))
 })
 

--- a/tests/testthat/test-parsing-datetime.R
+++ b/tests/testthat/test-parsing-datetime.R
@@ -56,6 +56,12 @@ test_that("%OS captures partial seconds", {
   expect_equal(as.POSIXlt(x)$sec, 1.333, tol = 1e-6)
 })
 
+test_that("%y requries 4 digits", {
+  expect_warning(parse_date("003-01-01", "%Y-%m-%d"), "parsing failure")
+  expect_warning(parse_date("03-01-01", "%Y-%m-%d"), "parsing failure")
+  expect_warning(parse_date("00003-01-01", "%Y-%m-%d"), "parsing failure")
+})
+
 test_that("invalid dates return NA", {
   expect_warning(x <- parse_datetime("2010-02-30", "%Y-%m-%d"))
   expect_true(is.na(x))


### PR DESCRIPTION
Need to either consistently use flexible parser, or format specified in locale
or provide someway to select between them