### PR TITLE
Always print .0 after whole number decimals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -124,7 +124,9 @@ Date and time parsing functions received a number of small enhancements:
 * Printing double values now uses an
   [implementation](https://github.com/juj/MathGeoLib/blob/master/src/Math/grisu3.c)
   of the [grisu3 algorithm](http://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf)
-  which speeds up writing of large numeric data frames by ~10X. (#432)
+  which speeds up writing of large numeric data frames by ~10X. (#432) '.0' is
+  appended to whole number doubles, to ensure they will be read as doubles as
+  well. (#483)
 
 * readr imports tibble so that you get consistent `tbl_df` behaviour 
   (#317, #385).

--- a/src/grisu3.c
+++ b/src/grisu3.c
@@ -352,7 +352,7 @@ int dtoa_grisu3(double v, char *dst)
 	// Prehandle negative values.
 	if ((u64 & D64_SIGN) != 0) { *s2++ = '-'; v = -v; u64 ^= D64_SIGN; }
 	// Prehandle zero.
-	if (!u64) { *s2++ = '0'; *s2 = '\0'; return (int)(s2 - dst); }
+	if (!u64) { *s2++ = '0'; *s2++ = '.'; *s2++ = '0'; *s2 = '\0'; return (int)(s2 - dst); }
 	// Prehandle infinity.
 	if (u64 == D64_EXP_MASK) { *s2++ = 'i'; *s2++ = 'n'; *s2++ = 'f'; *s2 = '\0'; return (int)(s2 - dst); }
 
@@ -360,6 +360,14 @@ int dtoa_grisu3(double v, char *dst)
 	// If grisu3 was not able to convert the number to a string, then use old sprintf (suboptimal).
 	if (!success) return sprintf(s2, "%.17g", v) + (int)(s2 - dst);
 
+	// handle whole numbers
+	if (d_exp >= 0 && d_exp <= 2) {
+		while(d_exp-- > 0) s2[len++] = '0';
+		 s2[len++] = '.';
+		 s2[len++] = '0';
+		 s2[len] = '\0';
+		 return (int)(s2+len-dst);
+	}
 	// We now have an integer string of form "151324135" and a base-10 exponent for that number.
 	// Next, decide the best presentation for that string by whether to use a decimal point, or the scientific exponent notation 'e'.
 	// We don't pick the absolute shortest representation, but pick a balance between readability and shortness, e.g.
@@ -390,7 +398,6 @@ int dtoa_grisu3(double v, char *dst)
 	}// Add scientific notation?
 	else if (d_exp < 0 || d_exp > 2) { s2[len++] = 'e'; len += i_to_str(d_exp, s2+len); }
 	// Add zeroes instead of scientific notation?
-	else if (d_exp > 0) { while(d_exp-- > 0) s2[len++] = '0'; }
 	s2[len] = '\0'; // grisu3 doesn't null terminate, so ensure termination.
 	return (int)(s2+len-dst);
 }

--- a/tests/testthat/test-write-delim.R
+++ b/tests/testthat/test-write-delim.R
@@ -75,3 +75,20 @@ test_that("write_excel_csv includes a byte order mark", {
   # Rest of file also there
   expect_equal(output[4:6], charToRaw("mpg"))
 })
+
+
+test_that("writes a tailing .0 for whole number doubles", {
+  expect_equal(format_tsv(tibble::data_frame(x = 1)), "x\n1.0\n")
+
+  expect_equal(format_tsv(tibble::data_frame(x = 0)), "x\n0.0\n")
+
+  expect_equal(format_tsv(tibble::data_frame(x = -1)), "x\n-1.0\n")
+
+  expect_equal(format_tsv(tibble::data_frame(x = 999)), "x\n999.0\n")
+
+  expect_equal(format_tsv(tibble::data_frame(x = -999)), "x\n-999.0\n")
+
+  expect_equal(format_tsv(tibble::data_frame(x = 123456789)), "x\n123456789.0\n")
+
+  expect_equal(format_tsv(tibble::data_frame(x = -123456789)), "x\n-123456789.0\n")
+})


### PR DESCRIPTION
This ensures they will be read as decimals in the future.

If we want to go this route the implementation was not too hard to do.

Fixes #482