### PR TITLE
Handle printing of non-syntactic names in col specs

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -130,13 +130,18 @@ format.col_spec <- function(x, n = Inf, condense = NULL, ...) {
   cols_args <- c(default,
     vapply(seq_along(cols),
       function(i) {
-        col_names <- names(cols)[[i]]
         col_funs <- sub("^collector_", "col_", class(cols[[i]])[[1]])
         args <- vapply(cols[[i]], deparse, character(1))
         args <- paste(names(args), args, sep = " = ", collapse = ", ")
 
-        # Need to special case skipped columns without names
+        col_names <- names(cols)[[i]]
+
+        # Need to handle unnamed columns and columns with non-syntactic names
         named <- col_names != ""
+
+        non_syntactic <- !is_syntactic(col_names) & named
+        col_names[non_syntactic] <- paste0("`", col_names[non_syntactic], "`")
+
         out <- paste0(col_names, " = ", col_funs, "(", args, ")")
         out[!named] <- paste0(col_funs, "(", args, ")")
         out

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -140,7 +140,7 @@ format.col_spec <- function(x, n = Inf, condense = NULL, ...) {
         named <- col_names != ""
 
         non_syntactic <- !is_syntactic(col_names) & named
-        col_names[non_syntactic] <- paste0("`", col_names[non_syntactic], "`")
+        col_names[non_syntactic] <- paste0("`", gsub("`", "\\\\`", col_names[non_syntactic]), "`")
 
         out <- paste0(col_names, " = ", col_funs, "(", args, ")")
         out[!named] <- paste0(col_funs, "(", args, ")")

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,3 +7,5 @@ isFALSE <- function(x) identical(x, FALSE)
 is.connection <- function(x) inherits(x, "connection")
 
 `%||%` <- function(a, b) if (is.null(a)) b else a
+
+is_syntactic <- function(x) make.names(x) == x

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -205,3 +205,14 @@ test_that("print(col_spec) and condense edge cases", {
 )
 ")
 })
+
+test_that("non-syntatic names are escaped", {
+  x <- read_csv("a b,_c,1\n1,2,3")
+  expect_equal(format(spec(x)),
+"cols(
+  `a b` = col_integer(),
+  `_c` = col_integer(),
+  `1` = col_integer()
+)
+")
+})

--- a/tests/testthat/test-col-spec.R
+++ b/tests/testthat/test-col-spec.R
@@ -207,12 +207,13 @@ test_that("print(col_spec) and condense edge cases", {
 })
 
 test_that("non-syntatic names are escaped", {
-  x <- read_csv("a b,_c,1\n1,2,3")
+  x <- read_csv("a b,_c,1,a`b\n1,2,3,4")
   expect_equal(format(spec(x)),
 "cols(
   `a b` = col_integer(),
   `_c` = col_integer(),
-  `1` = col_integer()
+  `1` = col_integer(),
+  `a\\`b` = col_integer()
 )
 ")
 })


### PR DESCRIPTION
Fixes #486 