### PR TITLE
Update RCPP Dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Depends:
 LinkingTo: Rcpp,
     BH
 Imports:
-    Rcpp (>= 0.11.5),
+    Rcpp (>= 0.12.0.5),
     curl,
     tibble,
     hms,


### PR DESCRIPTION
write_delim.cpp uses vector.at() which was added in RCPP 0.12.0.5.

See change log for https://github.com/RcppCore/Rcpp/commit/e4868b8f3918dc2f9633c25d8169b53b0a22d1ad